### PR TITLE
Use project compiler options in test compilation

### DIFF
--- a/.github/workflows/mtgoparser-ci.yml
+++ b/.github/workflows/mtgoparser-ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 env:
-  CLANG_TIDY_VERSION: "15.0.0"
+  CLANG_TIDY_VERSION: "15.0.2"
   VERBOSE: 1
 
 
@@ -49,7 +49,7 @@ jobs:
           - macos-12
           - windows-2022
         compiler:
-          - llvm-15.0.0
+          - llvm-15.0.2
           - gcc-13
         generator:
           - "Ninja Multi-Config"
@@ -73,7 +73,7 @@ jobs:
             gcov_executable: gcov
             enable_ipo: On
 
-          - compiler: llvm-15.0.0
+          - compiler: llvm-15.0.2
             enable_ipo: Off
             gcov_executable: "llvm-cov gcov"
 

--- a/.github/workflows/mtgoparser-ci.yml
+++ b/.github/workflows/mtgoparser-ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 env:
-  CLANG_TIDY_VERSION: "15.0.4"
+  CLANG_TIDY_VERSION: "15.0.3"
   VERBOSE: 1
 
 
@@ -49,7 +49,7 @@ jobs:
           - macos-12
           - windows-2022
         compiler:
-          - llvm-15.0.4
+          - llvm-15.0.3
           - gcc-13
         generator:
           - "Ninja Multi-Config"
@@ -73,7 +73,7 @@ jobs:
             gcov_executable: gcov
             enable_ipo: On
 
-          - compiler: llvm-15.0.4
+          - compiler: llvm-15.0.3
             enable_ipo: Off
             gcov_executable: "llvm-cov gcov"
 

--- a/.github/workflows/mtgoparser-ci.yml
+++ b/.github/workflows/mtgoparser-ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 env:
-  CLANG_TIDY_VERSION: "15.0.2"
+  CLANG_TIDY_VERSION: "15.0.3"
   VERBOSE: 1
 
 
@@ -49,7 +49,7 @@ jobs:
           - macos-12
           - windows-2022
         compiler:
-          - llvm-15.0.2
+          - llvm-15.0.3
           - gcc-13
         generator:
           - "Ninja Multi-Config"
@@ -73,7 +73,7 @@ jobs:
             gcov_executable: gcov
             enable_ipo: On
 
-          - compiler: llvm-15.0.2
+          - compiler: llvm-15.0.3
             enable_ipo: Off
             gcov_executable: "llvm-cov gcov"
 

--- a/.github/workflows/mtgoparser-ci.yml
+++ b/.github/workflows/mtgoparser-ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 env:
-  CLANG_TIDY_VERSION: "15.0.3"
+  CLANG_TIDY_VERSION: "15.0.4"
   VERBOSE: 1
 
 
@@ -46,10 +46,10 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13
+          - macos-12
           - windows-2022
         compiler:
-          - llvm-15.0.3
+          - llvm-15.0.4
           - gcc-13
         generator:
           - "Ninja Multi-Config"
@@ -73,11 +73,11 @@ jobs:
             gcov_executable: gcov
             enable_ipo: On
 
-          - compiler: llvm-15.0.3
+          - compiler: llvm-15.0.4
             enable_ipo: Off
             gcov_executable: "llvm-cov gcov"
 
-          - os: macos-13
+          - os: macos-12
             enable_ipo: Off
 
           # Set up preferred package generators, for given build configurations

--- a/.github/workflows/mtgoparser-ci.yml
+++ b/.github/workflows/mtgoparser-ci.yml
@@ -50,7 +50,7 @@ jobs:
           - windows-2022
         compiler:
           - llvm-15.0.3
-          - gcc-13
+          - gcc-12
         generator:
           - "Ninja Multi-Config"
         build_type:
@@ -64,12 +64,12 @@ jobs:
         exclude:
           # mingw is determined by this author to be too buggy to support
           - os: windows-2022
-            compiler: gcc-13
+            compiler: gcc-12
 
         include:
           # Add appropriate variables for gcov version required. This will intentionally break
           # if you try to use a compiler that does not have gcov set
-          - compiler: gcc-13
+          - compiler: gcc-12
             gcov_executable: gcov
             enable_ipo: On
 
@@ -87,7 +87,7 @@ jobs:
 
           # This exists solely to make sure a non-multiconfig build works
           - os: ubuntu-22.04
-            compiler: gcc-13
+            compiler: gcc-12
             generator: "Unix Makefiles"
             build_type: Debug
             gcov_executable: gcov

--- a/.github/workflows/mtgoparser-ci.yml
+++ b/.github/workflows/mtgoparser-ci.yml
@@ -46,11 +46,11 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-12
+          - macos-13
           - windows-2022
         compiler:
           - llvm-15.0.3
-          - gcc-12
+          - gcc-13
         generator:
           - "Ninja Multi-Config"
         build_type:
@@ -64,12 +64,12 @@ jobs:
         exclude:
           # mingw is determined by this author to be too buggy to support
           - os: windows-2022
-            compiler: gcc-12
+            compiler: gcc-13
 
         include:
           # Add appropriate variables for gcov version required. This will intentionally break
           # if you try to use a compiler that does not have gcov set
-          - compiler: gcc-12
+          - compiler: gcc-13
             gcov_executable: gcov
             enable_ipo: On
 
@@ -77,7 +77,7 @@ jobs:
             enable_ipo: Off
             gcov_executable: "llvm-cov gcov"
 
-          - os: macos-12
+          - os: macos-13
             enable_ipo: Off
 
           # Set up preferred package generators, for given build configurations
@@ -87,7 +87,7 @@ jobs:
 
           # This exists solely to make sure a non-multiconfig build works
           - os: ubuntu-22.04
-            compiler: gcc-12
+            compiler: gcc-13
             generator: "Unix Makefiles"
             build_type: Debug
             gcov_executable: gcov

--- a/mtgoparser/CMakeLists.txt
+++ b/mtgoparser/CMakeLists.txt
@@ -75,7 +75,7 @@ write_basic_package_version_file(
 )
 install(TARGETS spdlog rapidxml fmt mtgoparser
 #install(TARGETS mtgoparser
-    EXPORT mtgoparserTargets
+    EXPORT mtgoparserTargets 
     LIBRARY DESTINATION lib COMPONENT Runtime
     ARCHIVE DESTINATION lib COMPONENT Development
     RUNTIME DESTINATION bin COMPONENT Runtime
@@ -103,11 +103,7 @@ if(NOT PROJECT_IS_TOP_LEVEL)
 endif()
 
 # Adding the tests:
-
-list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
-find_package(Catch2 3 REQUIRED)
 include(CTest)
-include(Catch)
 
 if(BUILD_TESTING)
   message(AUTHOR_WARNING "Building Tests. Be sure to check out test/constexpr_tests.cpp for constexpr testing")

--- a/mtgoparser/CMakeLists.txt
+++ b/mtgoparser/CMakeLists.txt
@@ -74,7 +74,6 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
 )
 install(TARGETS spdlog rapidxml fmt mtgoparser
-#install(TARGETS mtgoparser
     EXPORT mtgoparserTargets 
     LIBRARY DESTINATION lib COMPONENT Runtime
     ARCHIVE DESTINATION lib COMPONENT Development

--- a/mtgoparser/cmake/CompilerWarnings.cmake
+++ b/mtgoparser/cmake/CompilerWarnings.cmake
@@ -84,7 +84,11 @@ function(
   if(WARNINGS_AS_ERRORS)
     message(TRACE "Warnings are treated as errors")
     list(APPEND CLANG_WARNINGS -Werror)
-    list(APPEND GCC_WARNINGS -Werror)
+    if(CMAKE_SYSTEM_NAME MATCHES ".*Darwin.*" AND CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*" AND CMAKE_BUILD_TYPE MATCHES ".*Release.*")
+      message(AUTHOR_WARNING "Warnings are not treated as errors on: MacOS with GCC compiler in Release mode, due to high number of false positives")
+    else()
+      list(APPEND GCC_WARNINGS -Werror)
+    endif()
     list(APPEND MSVC_WARNINGS /WX)
   endif()
 

--- a/mtgoparser/include/mtgoparser/mtgo/xml.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/xml.hpp
@@ -61,7 +61,9 @@ namespace xml {
     // Iterate through all siblings
     for (decltype(auto) card = first_card_node; card; card = card->next_sibling()) {
       // Iterate through all attributes
-      if (auto c = card_from_xml(card)) { cards.emplace_back(c.value()); }
+      if (auto c = card_from_xml(card)) { cards.emplace_back(c.value()); } else { 
+        spdlog::error("Decoding card from XML failed"); 
+        }
     }
 
     return cards;

--- a/mtgoparser/include/mtgoparser/mtgo/xml.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/xml.hpp
@@ -61,9 +61,11 @@ namespace xml {
     // Iterate through all siblings
     for (decltype(auto) card = first_card_node; card; card = card->next_sibling()) {
       // Iterate through all attributes
-      if (auto c = card_from_xml(card)) { cards.emplace_back(c.value()); } else { 
-        spdlog::error("Decoding card from XML failed"); 
-        }
+      if (auto c = card_from_xml(card)) {
+        cards.emplace_back(c.value());
+      } else {
+        spdlog::error("Decoding card from XML failed");
+      }
     }
 
     return cards;

--- a/mtgoparser/test/CMakeLists.txt
+++ b/mtgoparser/test/CMakeLists.txt
@@ -23,12 +23,10 @@ include(Catch)
 add_executable(tests tests.cpp)
 target_link_libraries(tests PRIVATE
                                     mtgoparser::mtgoparser_warnings
-                                    #mtgoparser::mtgoparser_options
-                                    #mtgoparser::mtgoparser_optionstest
+                                    mtgoparser::mtgoparser_options
                                     mtgoparser
                                     Catch2::Catch2WithMain)
 
-message(VERBOSE "Is WIN32 and BUILD_SHARED_LIBS??")
 if(WIN32 AND BUILD_SHARED_LIBS)
   message(VERBOSE "WIN32 and BUILD_SHARED_LIBS")
   add_custom_command(

--- a/mtgoparser/test/CMakeLists.txt
+++ b/mtgoparser/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(../cmake/SystemLink.cmake)
 cmake_minimum_required(VERSION 3.15)
 
 project(mtgoparserTests LANGUAGES CXX)
@@ -24,8 +25,9 @@ add_executable(tests tests.cpp)
 target_link_libraries(tests PRIVATE
                                     mtgoparser::mtgoparser_warnings
                                     mtgoparser::mtgoparser_options
-                                    mtgoparser
-                                    Catch2::Catch2WithMain)
+                                    mtgoparser)
+target_link_system_library(tests PRIVATE Catch2::Catch2WithMain)
+
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   message(VERBOSE "WIN32 and BUILD_SHARED_LIBS")

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,8 +1,15 @@
 #include <catch2/catch_test_macros.hpp>
 
+#if defined(__GNUC__)
 // False positive on macos-12 GCC-13 with Release mode.
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 #include <mtgoparser/mtgo.hpp>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 
 TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,3 +1,4 @@
+// NOLINTBEGIN
 // False positive on macos-12 GCC-13 with Release mode.
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__has_warning)
 #define SUPPRESSING
@@ -51,3 +52,4 @@ TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")
 #pragma message "Reverting local warning suppressions"
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,23 +1,5 @@
-// NOLINTBEGIN
-// False positive on macos-12 GCC-13 with Release mode.
-#if (defined(__GNUC__) || defined(__clang__)) && defined(__has_warning)
-#define SUPPRESSING
-#pragma GCC diagnostic push
-#if defined(__clang__)
-// #pragma clang diagnostic ignored "-Werror"
-#else
-#pragma GCC diagnostic ignored "-Werror"
-#endif
-
-#if __has_warning("-Warray-bounds")
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-#if __has_warning("-Wstringop-overread")
-#pragma GCC diagnostic ignored "-Wstringop-overread"
-#endif
-#endif
-
 #include <catch2/catch_test_macros.hpp>
+
 #include <mtgoparser/mtgo.hpp>
 
 
@@ -32,10 +14,3 @@ TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")
     CHECK(cards[0].id_ == "1");
   }
 }
-
-
-#ifdef SUPPRESSING
-#undef SUPPRESSING
-#pragma GCC diagnostic pop
-#endif
-// NOLINTEND

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_test_macros.hpp>
 
 
 // False positive on macos-12 GCC-13 with Release mode.
@@ -13,12 +12,8 @@
 #endif
 #endif
 
+#include <catch2/catch_test_macros.hpp>
 #include <mtgoparser/mtgo.hpp>
-
-#ifdef SUPPRESSING
-#undef SUPPRESSING
-#pragma GCC diagnostic pop
-#endif
 
 
 TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")
@@ -32,3 +27,9 @@ TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")
     CHECK(cards[0].id_ == "1");
   }
 }
+
+
+#ifdef SUPPRESSING
+#undef SUPPRESSING
+#pragma GCC diagnostic pop
+#endif

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,13 +1,25 @@
-
-
 // False positive on macos-12 GCC-13 with Release mode.
-#if __GNUC__ && defined(__has_warning)
+#pragma message "Compiling tests.cpp"
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__has_warning)
+#pragma message "GNUC or CLANG and __has_warning defined -> suppressing selected warnings with false positives"
+#if defined(__GNUC__)
+#pragma message "GNUC defined"
+#endif
+#if defined(__clang__)
+#pragma message "clang defined"
+#endif
+#if defined(__has_warning)
+#pragma message "__has_warning defined"
+#endif
+
 #define SUPPRESSING
 #pragma GCC diagnostic push
 #if __has_warning("-Warray-bounds")
+#pragma message "Disabling warning: -Warray-bounds"
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 #if __has_warning("-Wstringop-overread")
+#pragma message "Disabling warning: -Wstringop-overread"
 #pragma GCC diagnostic ignored "-Wstringop-overread"
 #endif
 #endif
@@ -31,5 +43,6 @@ TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")
 
 #ifdef SUPPRESSING
 #undef SUPPRESSING
+#pragma message "Reverting local warning suppressions"
 #pragma GCC diagnostic pop
 #endif

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
-
+// False positive on macos-12 GCC-13 with Release mode.
+#pragma GCC diagnostic ignored "-Warray-bounds"
 #include <mtgoparser/mtgo.hpp>
 
 

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,6 +1,10 @@
 // False positive on macos-12 GCC-13 with Release mode.
-#pragma message "Compiling tests.cpp"
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__has_warning)
+#define SUPPRESSING
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Werror"
+
 #pragma message "GNUC or CLANG and __has_warning defined -> suppressing selected warnings with false positives"
 #if defined(__GNUC__)
 #pragma message "GNUC defined"
@@ -12,8 +16,6 @@
 #pragma message "__has_warning defined"
 #endif
 
-#define SUPPRESSING
-#pragma GCC diagnostic push
 #if __has_warning("-Warray-bounds")
 #pragma message "Disabling warning: -Warray-bounds"
 #pragma GCC diagnostic ignored "-Warray-bounds"

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -4,28 +4,15 @@
 #define SUPPRESSING
 #pragma GCC diagnostic push
 #if defined(__clang__)
-#pragma clang diagnostic ignored "-Werror"
+// #pragma clang diagnostic ignored "-Werror"
 #else
 #pragma GCC diagnostic ignored "-Werror"
 #endif
 
-#pragma message "GNUC or CLANG and __has_warning defined -> suppressing selected warnings with false positives"
-#if defined(__GNUC__)
-#pragma message "GNUC defined"
-#endif
-#if defined(__clang__)
-#pragma message "clang defined"
-#endif
-#if defined(__has_warning)
-#pragma message "__has_warning defined"
-#endif
-
 #if __has_warning("-Warray-bounds")
-#pragma message "Disabling warning: -Warray-bounds"
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 #if __has_warning("-Wstringop-overread")
-#pragma message "Disabling warning: -Wstringop-overread"
 #pragma GCC diagnostic ignored "-Wstringop-overread"
 #endif
 #endif
@@ -49,7 +36,6 @@ TEST_CASE("Card structs can be deserialized from XML", "[cards_from_xml]")
 
 #ifdef SUPPRESSING
 #undef SUPPRESSING
-#pragma message "Reverting local warning suppressions"
 #pragma GCC diagnostic pop
 #endif
 // NOLINTEND

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -2,8 +2,11 @@
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__has_warning)
 #define SUPPRESSING
 #pragma GCC diagnostic push
-
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Werror"
+#else
 #pragma GCC diagnostic ignored "-Werror"
+#endif
 
 #pragma message "GNUC or CLANG and __has_warning defined -> suppressing selected warnings with false positives"
 #if defined(__GNUC__)

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -1,14 +1,22 @@
 #include <catch2/catch_test_macros.hpp>
 
-#if defined(__GNUC__)
+
 // False positive on macos-12 GCC-13 with Release mode.
+#if __GNUC__ && defined(__has_warning)
+#define SUPPRESSING
 #pragma GCC diagnostic push
+#if __has_warning("-Warray-bounds")
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+#if __has_warning("-Wstringop-overread")
 #pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
 #endif
 
 #include <mtgoparser/mtgo.hpp>
-#if defined(__GNUC__)
+
+#ifdef SUPPRESSING
+#undef SUPPRESSING
 #pragma GCC diagnostic pop
 #endif
 

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -4,6 +4,7 @@
 // False positive on macos-12 GCC-13 with Release mode.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
 #endif
 
 #include <mtgoparser/mtgo.hpp>


### PR DESCRIPTION
Enables the compiler options used to compile the library when linking it to the test binary (currently only one test binary)