### PR TITLE
Mtgoparser support more prices

### DIFF
--- a/mtgogetter/cmd/mtgogetter/download/scryfall-bulk.go
+++ b/mtgogetter/cmd/mtgogetter/download/scryfall-bulk.go
@@ -112,7 +112,8 @@ The data comes as a JSON file containing every card object on Scryfall in Englis
 		stream_decoder := json.NewDecoder(resp_bulk_data.Body)
 
 		// Deserialize to the ScryfallCard struct (Taking only the fields we need)
-		scryfall_cards, err := mtgogetter.ScryfallCardsFromJsonStream(stream_decoder)
+		// Preallocate 100,000 cards (most recent bulk data as of 2023-09-11 contains 87,000 cards, so 100,000 should be enough for a while)
+		scryfall_cards, err := mtgogetter.ScryfallCardsFromStreamPrealloc(stream_decoder, 100000)
 		if err != nil {
 			return fmt.Errorf("error when deserializing JSON stream: %s", err)
 		}

--- a/mtgogetter/pkg/mtgogetter/mtgogetter.go
+++ b/mtgogetter/pkg/mtgogetter/mtgogetter.go
@@ -151,3 +151,26 @@ func Retry[T any](attempts int, sleep_ms int, f func() (T, error)) (result T, er
 	}
 	return result, fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }
+
+// Function for filtering from a slice with a predicate, and returning a new slice
+// https://stackoverflow.com/a/37563128
+func Filter[T any](ss []T, test func(T) bool) (ret []T) {
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}
+
+// Function for filtering from a slice with a predicate, and returning a new slice that is preallocated
+// adapted from: https://stackoverflow.com/a/37563128
+func FilterPrealloc[T any](ss []T, test func(T) bool, prealloc int) []T {
+	ret := make([]T, 0, prealloc)
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return ret
+}

--- a/mtgogetter/pkg/mtgogetter/scryfall_parse.go
+++ b/mtgogetter/pkg/mtgogetter/scryfall_parse.go
@@ -6,12 +6,11 @@ import (
 )
 
 type ScryfallCard struct {
-	Mtgo_id      int32    `json:"mtgo_id"`
-	Mtgo_foil_id int32    `json:"mtgo_foil_id"`
-	Name         string   `json:"name"`
-	Released_at  string   `json:"released_at"`
-	Rarity       string   `json:"rarity"`
-	Prices       struct { // All nullable (deserialized as empty string if null)
+	Mtgo_id     int32    `json:"mtgo_id"`
+	Name        string   `json:"name"`
+	Released_at string   `json:"released_at"`
+	Rarity      string   `json:"rarity"`
+	Prices      struct { // All nullable (deserialized as empty string if null)
 		Usd      string `json:"usd"`
 		Usd_foil string `json:"usd_foil"`
 		Eur      string `json:"eur"`

--- a/mtgogetter/pkg/mtgogetter/scryfall_parse_test.go
+++ b/mtgogetter/pkg/mtgogetter/scryfall_parse_test.go
@@ -107,9 +107,80 @@ func TestScryfallJson_Deserialize_50cards(t *testing.T) {
 	f_scryfall_json := "../../../test/test-data/scryfall/default-cards-small-87objs-50cards.json"
 
 	bulk_data, err := ScryfallCardsFromFile(f_scryfall_json)
+	if err != nil {
+		t.Fatalf("Error when parsing Scryfall JSON: %s", err)
+	}
 
 	if len(bulk_data) != 50 {
 		t.Errorf("Expected 50 cards got %d", len(bulk_data))
+	}
+
+	if err != nil {
+		t.Errorf("Error when parsing Scryfall JSON: %s", err)
+	}
+
+	first_card := &bulk_data[0]
+
+	if first_card.Mtgo_id != 25527 {
+		t.Errorf("Expected 25527 got %d", first_card.Mtgo_id)
+	}
+
+	if first_card.Mtgo_foil_id != 25528 {
+		t.Errorf("Expected 25528 got %d", first_card.Mtgo_foil_id)
+	}
+
+	if first_card.Name != "Fury Sliver" {
+		t.Errorf("Expected Fury Sliver got %s", bulk_data[0].Name)
+	}
+
+	if first_card.Prices.Usd != "0.47" {
+		t.Errorf("Expected 0.47 got %s", bulk_data[0].Prices.Usd)
+	}
+
+	second_card := &bulk_data[1]
+
+	if second_card.Mtgo_id != 34586 {
+		t.Errorf("Expected 34586 got %d", second_card.Mtgo_id)
+	}
+
+	if second_card.Mtgo_foil_id != 34587 {
+		t.Errorf("Expected 34587 got %d", second_card.Mtgo_foil_id)
+	}
+
+	// Check third card
+	third_card := &bulk_data[2]
+
+	if third_card.Mtgo_id != 65170 {
+		t.Errorf("Expected 65170 got %d", third_card.Mtgo_id)
+	}
+
+	if third_card.Mtgo_foil_id != 65171 {
+		t.Errorf("Expected 65170 got %d", third_card.Mtgo_foil_id)
+	}
+
+	if third_card.Prices.Usd != "0.03" {
+		t.Errorf("Expected 0.03, got %s", third_card.Prices.Usd)
+	}
+
+	if third_card.Prices.Tix != "0.03" {
+		t.Errorf("Expected 0.03 got %s", third_card.Prices.Tix)
+	}
+}
+
+func TestScryfallJson_Deserialize_50cards_streamed(t *testing.T) {
+	// Contains 50 cards with mtgo_id (cards that exist on MTGO)
+	// But contains 87 card objects in total
+	// the cards that don't exist on MTGO have mtgo_id == 0 and should not be deserialized
+	f_scryfall_json := "../../../test/test-data/scryfall/default-cards-small-87objs-50cards.json"
+
+	bulk_data, err := ScryfallCardsFromFileStreamed(f_scryfall_json)
+
+	if err != nil {
+		t.Fatalf("Error when parsing Scryfall JSON: %s", err)
+	}
+
+	if len(bulk_data) != 50 {
+		t.Fatalf("Expected 50 cards got %d", len(bulk_data))
 	}
 
 	if err != nil {

--- a/mtgogetter/pkg/mtgogetter/scryfall_parse_test.go
+++ b/mtgogetter/pkg/mtgogetter/scryfall_parse_test.go
@@ -99,3 +99,67 @@ func TestScryfallJsonSerialize(t *testing.T) {
 	}
 
 }
+
+func TestScryfallJson_Deserialize_50cards(t *testing.T) {
+	// Contains 50 cards with mtgo_id (cards that exist on MTGO)
+	// But contains 87 card objects in total
+	// the cards that don't exist on MTGO have mtgo_id == 0 and should not be deserialized
+	f_scryfall_json := "../../../test/test-data/scryfall/default-cards-small-87objs-50cards.json"
+
+	bulk_data, err := ScryfallCardsFromFile(f_scryfall_json)
+
+	if len(bulk_data) != 50 {
+		t.Errorf("Expected 50 cards got %d", len(bulk_data))
+	}
+
+	if err != nil {
+		t.Errorf("Error when parsing Scryfall JSON: %s", err)
+	}
+
+	first_card := &bulk_data[0]
+
+	if first_card.Mtgo_id != 25527 {
+		t.Errorf("Expected 25527 got %d", first_card.Mtgo_id)
+	}
+
+	if first_card.Mtgo_foil_id != 25528 {
+		t.Errorf("Expected 25528 got %d", first_card.Mtgo_foil_id)
+	}
+
+	if first_card.Name != "Fury Sliver" {
+		t.Errorf("Expected Fury Sliver got %s", bulk_data[0].Name)
+	}
+
+	if first_card.Prices.Usd != "0.47" {
+		t.Errorf("Expected 0.47 got %s", bulk_data[0].Prices.Usd)
+	}
+
+	second_card := &bulk_data[1]
+
+	if second_card.Mtgo_id != 34586 {
+		t.Errorf("Expected 34586 got %d", second_card.Mtgo_id)
+	}
+
+	if second_card.Mtgo_foil_id != 34587 {
+		t.Errorf("Expected 34587 got %d", second_card.Mtgo_foil_id)
+	}
+
+	// Check third card
+	third_card := &bulk_data[2]
+
+	if third_card.Mtgo_id != 65170 {
+		t.Errorf("Expected 65170 got %d", third_card.Mtgo_id)
+	}
+
+	if third_card.Mtgo_foil_id != 65171 {
+		t.Errorf("Expected 65170 got %d", third_card.Mtgo_foil_id)
+	}
+
+	if third_card.Prices.Usd != "0.03" {
+		t.Errorf("Expected 0.03, got %s", third_card.Prices.Usd)
+	}
+
+	if third_card.Prices.Tix != "0.03" {
+		t.Errorf("Expected 0.03 got %s", third_card.Prices.Tix)
+	}
+}

--- a/mtgogetter/pkg/mtgogetter/scryfall_parse_test.go
+++ b/mtgogetter/pkg/mtgogetter/scryfall_parse_test.go
@@ -25,10 +25,6 @@ func TestScryfallJsonDeserialize(t *testing.T) {
 		t.Errorf("Expected 25527 got %d", first_card.Mtgo_id)
 	}
 
-	if first_card.Mtgo_foil_id != 25528 {
-		t.Errorf("Expected 25528 got %d", first_card.Mtgo_foil_id)
-	}
-
 	if first_card.Name != "Fury Sliver" {
 		t.Errorf("Expected Fury Sliver got %s", bulk_data[0].Name)
 	}
@@ -43,20 +39,12 @@ func TestScryfallJsonDeserialize(t *testing.T) {
 		t.Errorf("Expected 31745 got %d", second_card.Mtgo_id)
 	}
 
-	if second_card.Mtgo_foil_id != 31746 {
-		t.Errorf("Expected 31746 got %d", second_card.Mtgo_foil_id)
-	}
-
 	// Check third cards prices
 	// Black Lotus from Vintage Masters (only on MTGO so other prices are null)
 	third_lotus := &bulk_data[2]
 
 	if third_lotus.Mtgo_id != 53155 {
 		t.Errorf("Expected 53155 got %d", third_lotus.Mtgo_id)
-	}
-
-	if third_lotus.Mtgo_foil_id != 53156 {
-		t.Errorf("Expected 53156 got %d", third_lotus.Mtgo_foil_id)
 	}
 
 	if third_lotus.Prices.Usd != "" { // null in JSON
@@ -125,10 +113,6 @@ func TestScryfallJson_Deserialize_50cards(t *testing.T) {
 		t.Errorf("Expected 25527 got %d", first_card.Mtgo_id)
 	}
 
-	if first_card.Mtgo_foil_id != 25528 {
-		t.Errorf("Expected 25528 got %d", first_card.Mtgo_foil_id)
-	}
-
 	if first_card.Name != "Fury Sliver" {
 		t.Errorf("Expected Fury Sliver got %s", bulk_data[0].Name)
 	}
@@ -143,19 +127,11 @@ func TestScryfallJson_Deserialize_50cards(t *testing.T) {
 		t.Errorf("Expected 34586 got %d", second_card.Mtgo_id)
 	}
 
-	if second_card.Mtgo_foil_id != 34587 {
-		t.Errorf("Expected 34587 got %d", second_card.Mtgo_foil_id)
-	}
-
 	// Check third card
 	third_card := &bulk_data[2]
 
 	if third_card.Mtgo_id != 65170 {
 		t.Errorf("Expected 65170 got %d", third_card.Mtgo_id)
-	}
-
-	if third_card.Mtgo_foil_id != 65171 {
-		t.Errorf("Expected 65170 got %d", third_card.Mtgo_foil_id)
 	}
 
 	if third_card.Prices.Usd != "0.03" {
@@ -193,10 +169,6 @@ func TestScryfallJson_Deserialize_50cards_streamed(t *testing.T) {
 		t.Errorf("Expected 25527 got %d", first_card.Mtgo_id)
 	}
 
-	if first_card.Mtgo_foil_id != 25528 {
-		t.Errorf("Expected 25528 got %d", first_card.Mtgo_foil_id)
-	}
-
 	if first_card.Name != "Fury Sliver" {
 		t.Errorf("Expected Fury Sliver got %s", bulk_data[0].Name)
 	}
@@ -211,19 +183,11 @@ func TestScryfallJson_Deserialize_50cards_streamed(t *testing.T) {
 		t.Errorf("Expected 34586 got %d", second_card.Mtgo_id)
 	}
 
-	if second_card.Mtgo_foil_id != 34587 {
-		t.Errorf("Expected 34587 got %d", second_card.Mtgo_foil_id)
-	}
-
 	// Check third card
 	third_card := &bulk_data[2]
 
 	if third_card.Mtgo_id != 65170 {
 		t.Errorf("Expected 65170 got %d", third_card.Mtgo_id)
-	}
-
-	if third_card.Mtgo_foil_id != 65171 {
-		t.Errorf("Expected 65170 got %d", third_card.Mtgo_foil_id)
 	}
 
 	if third_card.Prices.Usd != "0.03" {

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -59,7 +59,7 @@ void Collection::ExtractGoatbotsInfo(const goatbots::card_defs_map_t &card_defs,
     }
     // Extract price from goatbots price history
     if (auto res = price_hist.find(c.id_); res != price_hist.end()) {
-      c.price_ = res->second;
+      c.goatbots_price_ = res->second;
     } else {
       spdlog::warn("Price history key not found: ID={}", c.id_);
     }
@@ -85,7 +85,7 @@ void Collection::Print() const
     spdlog::info("{} {}: price={}, quantity={}, set={}, foil={}, rarity={}",
       c.id_,
       c.name_,
-      c.price_,
+      c.goatbots_price_,
       c.quantity_,
       c.set_,
       c.foil_,

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -27,9 +27,10 @@ struct Card
     std::string set = "",
     std::string rarity = "",
     bool foil = false,
-    double goatbots_price = 0) noexcept
+    double goatbots_price = 0,
+    double scryfall_price = 0) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
-      goatbots_price_{ goatbots_price }
+      goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
   {}
 
   // Partially parametrised constructor used to construct a card from MTGO .dek XML
@@ -39,9 +40,10 @@ struct Card
     const char *set = "",
     const char *rarity = "",
     bool foil = false,
-    double goatbots_price = 0) noexcept
+    double goatbots_price = 0,
+    double scryfall_price = 0) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
-      goatbots_price_{ goatbots_price }
+      goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
   {}
 
   // SAFETY: The string_views used for construction has to outlive the constructed instance
@@ -52,24 +54,32 @@ struct Card
     std::string_view set,
     std::string_view rarity,
     bool foil = false,
-    double goatbots_price = 0) noexcept
+    double goatbots_price = 0,
+    double scryfall_price = 0) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
-      goatbots_price_{ goatbots_price }
+      goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
   {}
 
   // Templated constructor
   template<typename T>
     requires std::convertible_to<T, std::string>
-  explicit Card(T id, T quantity, T name, T set, T rarity, bool foil = false, double goatbots_price = 0) noexcept
+  explicit Card(T id,
+    T quantity,
+    T name,
+    T set,
+    T rarity,
+    bool foil = false,
+    double goatbots_price = 0,
+    double scryfall_price = 0) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
-      goatbots_price_{ goatbots_price }
+      goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
   {}
 
   // Move constructor
   [[nodiscard]] Card(Card &&other) noexcept
     : id_(std::move(other.id_)), quantity_(std::move(other.quantity_)), name_(std::move(other.name_)),
       set_(std::move(other.set_)), rarity_(std::move(other.rarity_)), foil_(other.foil_),
-      goatbots_price_(other.goatbots_price_)
+      goatbots_price_(other.goatbots_price_), scryfall_price_(other.scryfall_price_)
   {}
 
   // Move assignment operator
@@ -83,6 +93,7 @@ struct Card
       rarity_ = std::move(other.rarity_);
       foil_ = other.foil_;
       goatbots_price_ = other.goatbots_price_;
+      scryfall_price_ = other.scryfall_price_;
     }
 
     return *this;
@@ -106,5 +117,7 @@ template<> struct glz::meta<mtgo::Card>
     "foil",
     &T::foil_,
     "goatbots_price",
-    &T::goatbots_price_);
+    &T::goatbots_price_,
+    "scryfall_price",
+    &T::scryfall_price_);
 };

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -6,8 +6,19 @@
 #include <string_view>
 
 namespace mtgo {
+
 struct Card
 {
+  std::string id_;
+  std::string quantity_;
+  std::string name_;
+  std::string set_;
+  std::string rarity_;
+  bool foil_;
+  double goatbots_price_;
+  double scryfall_price_;
+
+
   // Default constructor
   // Note: some builds raises false positives in static analysis when simply declared as `Card() = default` )
   [[nodiscard]] explicit Card(std::string id = "",
@@ -16,8 +27,9 @@ struct Card
     std::string set = "",
     std::string rarity = "",
     bool foil = false,
-    double price = 0) noexcept
-    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil }, price_{ price }
+    double goatbots_price = 0) noexcept
+    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
+      goatbots_price_{ goatbots_price }
   {}
 
   // Partially parametrised constructor used to construct a card from MTGO .dek XML
@@ -27,8 +39,9 @@ struct Card
     const char *set = "",
     const char *rarity = "",
     bool foil = false,
-    double price = 0) noexcept
-    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil }, price_{ price }
+    double goatbots_price = 0) noexcept
+    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
+      goatbots_price_{ goatbots_price }
   {}
 
   // SAFETY: The string_views used for construction has to outlive the constructed instance
@@ -39,21 +52,24 @@ struct Card
     std::string_view set,
     std::string_view rarity,
     bool foil = false,
-    double price = 0) noexcept
-    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil }, price_{ price }
+    double goatbots_price = 0) noexcept
+    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
+      goatbots_price_{ goatbots_price }
   {}
 
   // Templated constructor
   template<typename T>
-  requires std::convertible_to<T, std::string>
-  explicit Card(T id, T quantity, T name, T set, T rarity, bool foil = false, double price = 0) noexcept
-    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil }, price_{ price }
+    requires std::convertible_to<T, std::string>
+  explicit Card(T id, T quantity, T name, T set, T rarity, bool foil = false, double goatbots_price = 0) noexcept
+    : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ rarity }, foil_{ foil },
+      goatbots_price_{ goatbots_price }
   {}
 
   // Move constructor
   [[nodiscard]] Card(Card &&other) noexcept
     : id_(std::move(other.id_)), quantity_(std::move(other.quantity_)), name_(std::move(other.name_)),
-      set_(std::move(other.set_)), rarity_(std::move(other.rarity_)), foil_(other.foil_), price_(other.price_)
+      set_(std::move(other.set_)), rarity_(std::move(other.rarity_)), foil_(other.foil_),
+      goatbots_price_(other.goatbots_price_)
   {}
 
   // Move assignment operator
@@ -66,19 +82,11 @@ struct Card
       set_ = std::move(other.set_);
       rarity_ = std::move(other.rarity_);
       foil_ = other.foil_;
-      price_ = other.price_;
+      goatbots_price_ = other.goatbots_price_;
     }
 
     return *this;
   }
-
-  std::string id_;
-  std::string quantity_;
-  std::string name_;
-  std::string set_;
-  std::string rarity_;
-  bool foil_;
-  double price_;
 };
 }// namespace mtgo
 
@@ -97,6 +105,6 @@ template<> struct glz::meta<mtgo::Card>
     &T::rarity_,
     "foil",
     &T::foil_,
-    "price",
-    &T::price_);
+    "goatbots_price",
+    &T::goatbots_price_);
 };

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -62,7 +62,7 @@ struct Card
 
   // Templated constructor
   template<typename T>
-    requires std::convertible_to<T, std::string>
+  requires std::convertible_to<T, std::string>
   explicit Card(T id,
     T quantity,
     T name,

--- a/mtgoparser/src/mtgo_preprocessor/main.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/main.cpp
@@ -114,7 +114,7 @@ auto scryfall_cards_parse() -> scryfall::scryfall_card_vec
   return scryfall_card_vec.value();
 }
 
-auto collection_parse(const std::string &test_data_dir) -> int
+void collection_parse(const std::string &test_data_dir)
 {
   spdlog::info("=== example_collection_parse ===");
 
@@ -129,6 +129,8 @@ auto collection_parse(const std::string &test_data_dir) -> int
   auto collection = mtgo::Collection(std::move(cards));
 
   auto scryfall_cards = scryfall_cards_parse();
+  spdlog::info("got {} scryfall cards", scryfall_cards.size());
+  spdlog::warn("TODO: Parse scryfall cards into collection info");
 
   spdlog::info("==> collection extract goatbots info...");
   collection.ExtractGoatbotsInfo(card_defs.value(), prices);
@@ -150,8 +152,6 @@ auto collection_parse(const std::string &test_data_dir) -> int
   auto new_collection = mtgo::Collection(collection_json);
   spdlog::info("==> new collection print...");
   new_collection.Print();
-
-  return 0;
 }
 
 void json_format_prints()
@@ -267,8 +267,8 @@ int main(int argc, char *argv[])
 
 
   if (config.FlagSet("--example", "--run-example", "--run")) {
-    auto res = example::collection_parse(test_data_dir);
-    if (res == 0) { spdlog::info("Example complete!"); }
+    example::collection_parse(test_data_dir);
+    spdlog::info("Example complete!");
   }
 
   if (config.FlagSet("--example-json-formats", "--example-json", "--run-example-json")) {

--- a/mtgoparser/src/mtgo_preprocessor/main.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/main.cpp
@@ -24,7 +24,7 @@ const auto test_path_trade_list_small_5cards = "/mtgo/Full Trade List-small-5car
 const auto test_path_goatbots_card_defs_small = "/goatbots/card-defs-small-5cards.json";
 const auto test_path_goatbots_price_hist_small = "/goatbots/price-hist-small-5cards.json";
 // Relative to a project subfolder such as mtgoparser/mtgogetter/mtgoupdater
-const auto top_test_dir_path = "../test/test-data";
+// const auto top_test_dir_path = "../test/test-data";
 const auto top_path_scryfall_default_small_500cards = "../test/test-data/mtgogetter-out/scryfall-small-100cards.json";
 
 

--- a/mtgoparser/src/mtgo_preprocessor/main.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/main.cpp
@@ -138,7 +138,7 @@ void json_format_prints()
   std::string_view name = "Godzilla";
   std::string_view set = "Best Set";
   std::string_view rarity = "Mythic";
-  mtgo::Card mtgo_card_vals = mtgo::Card(id, quantity, name, set, rarity, true, 100.);
+  mtgo::Card mtgo_card_vals = mtgo::Card(id, quantity, name, set, rarity, true, 100.1239, 0.6);
   std::string out_json_overwritten_vals_mtgo;
   glz::write_json(mtgo_card_vals, out_json_overwritten_vals_mtgo);
   fmt::print("{}\n", out_json_overwritten_vals_mtgo);

--- a/mtgoparser/src/mtgo_preprocessor/main.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/main.cpp
@@ -25,29 +25,45 @@ const auto test_path_goatbots_card_defs_small = "/goatbots/card-defs-small-5card
 const auto test_path_goatbots_price_hist_small = "/goatbots/price-hist-small-5cards.json";
 
 namespace example {
-auto collection_parse(const std::string &test_data_dir) -> int
-{
-  spdlog::info("=== example_collection_parse ===");
-  using goatbots::card_defs_map_t;
-  using goatbots::CardDefinition;
-  using goatbots::price_hist_map_t;
+using goatbots::card_defs_map_t;
+using goatbots::price_hist_map_t;
 
-  spdlog::info("==> parsing goatbots json...");
+
+auto goatbots_card_definitions_parse(const std::string &test_data_dir) -> std::optional<card_defs_map_t>
+{
   spdlog::info("=> parsing goatbots card definitions from {}...", test_data_dir + test_path_goatbots_card_defs_small);
   std::optional<card_defs_map_t> card_defs =
     goatbots::ReadJsonMap<card_defs_map_t>(test_data_dir + test_path_goatbots_card_defs_small);
   if (!card_defs.has_value()) {
     // Error: ReadJsonMap() failed
-    return 1;
+    return std::nullopt;
   }
+  return card_defs;
+}
 
+auto goatbots_price_history_parse(const std::string &test_data_dir) -> price_hist_map_t
+{
   spdlog::info(
     "=> parsing goatbots price history json from {}...", test_data_dir + test_path_goatbots_price_hist_small);
   price_hist_map_t prices =
     goatbots::ReadJsonMap<price_hist_map_t>(test_data_dir + test_path_goatbots_price_hist_small).value();
+  return prices;
+}
+
+auto collection_parse(const std::string &test_data_dir) -> int
+{
+  spdlog::info("=== example_collection_parse ===");
+
+
+  spdlog::info("==> parsing goatbots json...");
+  auto card_defs = goatbots_card_definitions_parse(test_data_dir);
+
+  price_hist_map_t prices = goatbots_price_history_parse(test_data_dir);
+
   spdlog::info("==> parsing mtgo xml...");
   auto cards = mtgo::xml::parse_dek_xml(test_data_dir + test_path_trade_list_small_5cards);
   auto collection = mtgo::Collection(std::move(cards));
+
   spdlog::info("==> collection extract goatbots info...");
   collection.ExtractGoatbotsInfo(card_defs.value(), prices);
 

--- a/mtgoparser/test/test_json_parse.cpp
+++ b/mtgoparser/test/test_json_parse.cpp
@@ -105,7 +105,6 @@ TEST_CASE("Scryfall JSON serializing", "[scryfall_serializing]")
     scryfall::Card card_default{};
 
     REQUIRE(card_default.mtgo_id == 0);
-    REQUIRE(card_default.mtgo_foil_id == 0);
     REQUIRE(card_default.name == "");
     REQUIRE(card_default.rarity == "");
     REQUIRE(card_default.released_at == "");
@@ -129,19 +128,15 @@ TEST_CASE("Scryfall JSON serializing", "[scryfall_serializing]")
     {
       {
         scryfall::Card card_vals{
-          0, 1, "Mother of Runes", "2006-10-06", "rare", scryfall::Prices{ "0", "0.2", "3.0", std::nullopt, "0.05" }
+          0, "Mother of Runes", "2006-10-06", "rare", scryfall::Prices{ "0", "0.2", "3.0", std::nullopt, "0.05" }
         };
 
         // Construction with initializer list should be equivelant as
-        REQUIRE(card_vals
-                == scryfall::Card(0,
-                  1,
-                  "Mother of Runes",
-                  "2006-10-06",
-                  "rare",
-                  scryfall::Prices{ "0", "0.2", "3.0", std::nullopt, "0.05" }));
+        REQUIRE(
+          card_vals
+          == scryfall::Card(
+            0, "Mother of Runes", "2006-10-06", "rare", scryfall::Prices{ "0", "0.2", "3.0", std::nullopt, "0.05" }));
         REQUIRE(card_vals.mtgo_id == 0);
-        REQUIRE(card_vals.mtgo_foil_id == 1);
         REQUIRE(card_vals.name == "Mother of Runes");
         REQUIRE(card_vals.rarity == "rare");
         REQUIRE(card_vals.released_at == "2006-10-06");

--- a/mtgoparser/test/test_json_parse.cpp
+++ b/mtgoparser/test/test_json_parse.cpp
@@ -117,7 +117,6 @@ TEST_CASE("Scryfall JSON serializing", "[scryfall_serializing]")
       glz::write_json(card_default, json_str_card_default);
 
       CHECK_THAT(json_str_card_default, ContainsSubstring(R"("mtgo_id":0)"));
-      CHECK_THAT(json_str_card_default, ContainsSubstring(R"("mtgo_foil_id":0)"));
       CHECK_THAT(json_str_card_default, ContainsSubstring(R"("name":"")"));
       CHECK_THAT(json_str_card_default, ContainsSubstring(R"("rarity":"")"));
       CHECK_THAT(json_str_card_default, ContainsSubstring(R"("prices":{})"));
@@ -150,7 +149,6 @@ TEST_CASE("Scryfall JSON serializing", "[scryfall_serializing]")
           glz::write_json(card_vals, json_str_card_vals);
 
           CHECK_THAT(json_str_card_vals, ContainsSubstring(R"("mtgo_id":0)"));
-          CHECK_THAT(json_str_card_vals, ContainsSubstring(R"("mtgo_foil_id":1)"));
           CHECK_THAT(json_str_card_vals, ContainsSubstring(R"("name":"Mother of Runes")"));
           CHECK_THAT(json_str_card_vals, ContainsSubstring(R"("rarity":"rare")"));
           CHECK_THAT(json_str_card_vals, ContainsSubstring(R"("released_at":"2006-10-06")"));
@@ -169,7 +167,6 @@ TEST_CASE("Scryfall JSON serializing", "[scryfall_serializing]")
             glz::write<glz::opts{ .skip_null_members = false }>(card_vals, json_str_card_vals_with_null);
 
             CHECK_THAT(json_str_card_vals_with_null, ContainsSubstring(R"("mtgo_id":0)"));
-            CHECK_THAT(json_str_card_vals_with_null, ContainsSubstring(R"("mtgo_foil_id":1)"));
             CHECK_THAT(json_str_card_vals_with_null, ContainsSubstring(R"("name":"Mother of Runes")"));
             CHECK_THAT(json_str_card_vals_with_null, ContainsSubstring(R"("rarity":"rare")"));
             CHECK_THAT(json_str_card_vals_with_null, ContainsSubstring(R"("released_at":"2006-10-06")"));

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Test CLAP with options and values")
       char *argv[] = { argv0, arg_save_as };
       int argc = 2;
       fmt::print("Got args:\n");
-      fmt::print("Should fail as --save-as doesn't have a value provided");
+      fmt::print("Should fail as --save-as doesn't have a value provided\n");
       CHECK(clap.Parse(argc, argv) != 0);
     }
 
@@ -96,7 +96,7 @@ TEST_CASE("Test CLAP with options and values")
       int argc = 3;
       fmt::print("Got args:\n");
       fmt::print(
-        "Should fail as --save-as doesn't have a value provided, instead it's followed by the --version option");
+        "Should fail as --save-as doesn't have a value provided, instead it's followed by the --version option\n");
       CHECK(clap.Parse(argc, argv) != 0);
     }
   }

--- a/test/test-data/mtgogetter-out/scryfall-card.json
+++ b/test/test-data/mtgogetter-out/scryfall-card.json
@@ -1,6 +1,5 @@
 {
     "mtgo_id": 25527,
-    "mtgo_foil_id": 25528,
     "name": "Fury Sliver",
     "released_at": "2006-10-06",
     "rarity": "uncommon",

--- a/test/test-data/mtgogetter-out/scryfall-small-100cards.json
+++ b/test/test-data/mtgogetter-out/scryfall-small-100cards.json
@@ -1,0 +1,1302 @@
+[
+    {
+      "mtgo_id": 25527,
+      "name": "Fury Sliver",
+      "released_at": "2006-10-06",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.47",
+        "usd_foil": "4.48",
+        "eur": "0.05",
+        "eur_foil": "0.50",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 34586,
+      "name": "Kor Outfitter",
+      "released_at": "2009-10-02",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.25",
+        "usd_foil": "7.87",
+        "eur": "0.25",
+        "eur_foil": "4.25",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 65170,
+      "name": "Siren Lookout",
+      "released_at": "2017-09-29",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.03",
+        "usd_foil": "0.22",
+        "eur": "0.17",
+        "eur_foil": "0.05",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 116428,
+      "name": "Obyra's Attendants // Desperate Parry",
+      "released_at": "2023-09-08",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.05",
+        "usd_foil": "0.12",
+        "eur": "0.08",
+        "eur_foil": "0.10",
+        "tix": "0.01"
+      }
+    },
+    {
+      "mtgo_id": 78170,
+      "name": "Venerable Knight",
+      "released_at": "2019-10-04",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.09",
+        "usd_foil": "0.28",
+        "eur": "0.07",
+        "eur_foil": "0.17",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 81171,
+      "name": "Mystic Skyfish",
+      "released_at": "2020-07-03",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.12",
+        "usd_foil": "",
+        "eur": "0.08",
+        "eur_foil": "",
+        "tix": "0.19"
+      }
+    },
+    {
+      "mtgo_id": 9701,
+      "name": "Swamp",
+      "released_at": "1997-10-14",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.39",
+        "usd_foil": "",
+        "eur": "0.10",
+        "eur_foil": "",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 102562,
+      "name": "Battlewing Mystic",
+      "released_at": "2022-09-09",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.04",
+        "usd_foil": "0.04",
+        "eur": "0.03",
+        "eur_foil": "0.09",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 38804,
+      "name": "Bronze Horse",
+      "released_at": "2011-01-10",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.05"
+      }
+    },
+    {
+      "mtgo_id": 14297,
+      "name": "Wall of Vipers",
+      "released_at": "2000-06-05",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.19",
+        "usd_foil": "8.39",
+        "eur": "0.10",
+        "eur_foil": "2.20",
+        "tix": "0.09"
+      }
+    },
+    {
+      "mtgo_id": 110316,
+      "name": "War Historian",
+      "released_at": "2023-04-21",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.01",
+        "usd_foil": "0.02",
+        "eur": "0.02",
+        "eur_foil": "0.02",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 108071,
+      "name": "Mystical Tutor",
+      "released_at": "2023-01-13",
+      "rarity": "rare",
+      "prices": {
+        "usd": "5.91",
+        "usd_foil": "9.34",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "1.25"
+      }
+    },
+    {
+      "mtgo_id": 95481,
+      "name": "Essence Warden",
+      "released_at": "2021-11-20",
+      "rarity": "rare",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.20"
+      }
+    },
+    {
+      "mtgo_id": 69499,
+      "name": "Blood Operative",
+      "released_at": "2018-10-05",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.10",
+        "usd_foil": "0.34",
+        "eur": "0.08",
+        "eur_foil": "0.49",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 39840,
+      "name": "Fresh Meat",
+      "released_at": "2011-05-13",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.21",
+        "usd_foil": "1.14",
+        "eur": "0.19",
+        "eur_foil": "0.99",
+        "tix": "0.01"
+      }
+    },
+    {
+      "mtgo_id": 47621,
+      "name": "Orzhov Guildgate",
+      "released_at": "2013-02-01",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.15",
+        "usd_foil": "2.37",
+        "eur": "0.05",
+        "eur_foil": "0.98",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 112892,
+      "name": "Mortify",
+      "released_at": "2023-06-23",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.16",
+        "usd_foil": "",
+        "eur": "0.18",
+        "eur_foil": "",
+        "tix": "0.26"
+      }
+    },
+    {
+      "mtgo_id": 86451,
+      "name": "Sinew Sliver",
+      "released_at": "2021-03-19",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.25",
+        "usd_foil": "1.72",
+        "eur": "0.15",
+        "eur_foil": "0.75",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 67485,
+      "name": "Charge",
+      "released_at": "2018-04-27",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.03",
+        "usd_foil": "0.11",
+        "eur": "0.02",
+        "eur_foil": "0.02",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 78656,
+      "name": "Island",
+      "released_at": "2019-10-04",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.08",
+        "usd_foil": "0.26",
+        "eur": "0.02",
+        "eur_foil": "0.12",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 68221,
+      "name": "Novice Knight",
+      "released_at": "2018-07-13",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.07",
+        "usd_foil": "0.43",
+        "eur": "0.09",
+        "eur_foil": "0.45",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 7545,
+      "name": "Fallen Askari",
+      "released_at": "1997-02-03",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.18",
+        "usd_foil": "",
+        "eur": "0.02",
+        "eur_foil": "",
+        "tix": "0.09"
+      }
+    },
+    {
+      "mtgo_id": 16777,
+      "name": "Afflict",
+      "released_at": "2001-10-01",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.17",
+        "usd_foil": "0.28",
+        "eur": "0.08",
+        "eur_foil": "0.30",
+        "tix": "0.06"
+      }
+    },
+    {
+      "mtgo_id": 113182,
+      "name": "Crown of Gondor",
+      "released_at": "2023-06-23",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.50",
+        "usd_foil": "",
+        "eur": "0.75",
+        "eur_foil": "",
+        "tix": "0.13"
+      }
+    },
+    {
+      "mtgo_id": 42282,
+      "name": "Invisible Stalker",
+      "released_at": "2011-09-30",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.49",
+        "usd_foil": "9.85",
+        "eur": "1.03",
+        "eur_foil": "5.00",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 90761,
+      "name": "Dakkon, Shadow Slayer",
+      "released_at": "2021-06-18",
+      "rarity": "mythic",
+      "prices": {
+        "usd": "0.37",
+        "usd_foil": "3.16",
+        "eur": "1.13",
+        "eur_foil": "3.49",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 62727,
+      "name": "Destructive Tampering",
+      "released_at": "2017-01-20",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.01",
+        "usd_foil": "0.21",
+        "eur": "0.10",
+        "eur_foil": "0.14",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 7171,
+      "name": "Nocturnal Raid",
+      "released_at": "1996-10-08",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.18",
+        "usd_foil": "",
+        "eur": "0.09",
+        "eur_foil": "",
+        "tix": "0.09"
+      }
+    },
+    {
+      "mtgo_id": 116290,
+      "name": "Archon of the Wild Rose",
+      "released_at": "2023-09-08",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.18",
+        "usd_foil": "0.29",
+        "eur": "0.23",
+        "eur_foil": "0.36",
+        "tix": "0.01"
+      }
+    },
+    {
+      "mtgo_id": 39473,
+      "name": "Flensermite",
+      "released_at": "2011-02-04",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.10",
+        "usd_foil": "2.73",
+        "eur": "0.45",
+        "eur_foil": "0.30",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 100590,
+      "name": "Gorion, Wise Mentor",
+      "released_at": "2022-06-10",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.13",
+        "usd_foil": "0.16",
+        "eur": "0.30",
+        "eur_foil": "0.25",
+        "tix": "0.15"
+      }
+    },
+    {
+      "mtgo_id": 56380,
+      "name": "Gate Smasher",
+      "released_at": "2015-03-27",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.05",
+        "usd_foil": "0.69",
+        "eur": "0.09",
+        "eur_foil": "0.12",
+        "tix": "0.05"
+      }
+    },
+    {
+      "mtgo_id": 59563,
+      "name": "World Breaker",
+      "released_at": "2016-01-22",
+      "rarity": "mythic",
+      "prices": {
+        "usd": "0.76",
+        "usd_foil": "5.01",
+        "eur": "2.50",
+        "eur_foil": "5.00",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 48672,
+      "name": "Mad Auntie",
+      "released_at": "2013-06-07",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.63",
+        "usd_foil": "0.91",
+        "eur": "0.59",
+        "eur_foil": "1.90",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 22387,
+      "name": "Coral Eel",
+      "released_at": "2005-07-29",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.15",
+        "usd_foil": "",
+        "eur": "0.08",
+        "eur_foil": "",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 110392,
+      "name": "Invasion of Tolvada // The Broken Sky",
+      "released_at": "2023-04-21",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.36",
+        "usd_foil": "0.49",
+        "eur": "0.42",
+        "eur_foil": "0.37",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 53035,
+      "name": "Spark Spray",
+      "released_at": "2014-06-16",
+      "rarity": "common",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 52505,
+      "name": "Remand",
+      "released_at": "2014-03-14",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "1.23",
+        "usd_foil": "",
+        "eur": "2.94",
+        "eur_foil": "",
+        "tix": "1.37"
+      }
+    },
+    {
+      "mtgo_id": 12977,
+      "name": "Bubbling Beebles",
+      "released_at": "1999-06-07",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.18",
+        "usd_foil": "9.15",
+        "eur": "0.07",
+        "eur_foil": "5.50",
+        "tix": "0.09"
+      }
+    },
+    {
+      "mtgo_id": 111968,
+      "name": "Second Breakfast",
+      "released_at": "2023-06-23",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.02",
+        "usd_foil": "0.09",
+        "eur": "0.02",
+        "eur_foil": "0.15",
+        "tix": "0.01"
+      }
+    },
+    {
+      "mtgo_id": 102062,
+      "name": "Ulasht, the Hate Seed",
+      "released_at": "2022-07-08",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.14",
+        "usd_foil": "0.26",
+        "eur": "0.15",
+        "eur_foil": "0.20",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 15948,
+      "name": "Unholy Strength",
+      "released_at": "2001-04-11",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.12",
+        "usd_foil": "",
+        "eur": "0.04",
+        "eur_foil": "",
+        "tix": "0.11"
+      }
+    },
+    {
+      "mtgo_id": 71464,
+      "name": "Consecrate // Consume",
+      "released_at": "2019-01-25",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.07",
+        "usd_foil": "0.27",
+        "eur": "0.02",
+        "eur_foil": "0.18",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 60863,
+      "name": "Thornwood Falls",
+      "released_at": "2016-06-10",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.06",
+        "usd_foil": "0.14",
+        "eur": "0.15",
+        "eur_foil": "0.99",
+        "tix": "0.05"
+      }
+    },
+    {
+      "mtgo_id": 105234,
+      "name": "Farid, Enterprising Salvager",
+      "released_at": "2022-11-18",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.10",
+        "usd_foil": "",
+        "eur": "0.14",
+        "eur_foil": "",
+        "tix": "0.20"
+      }
+    },
+    {
+      "mtgo_id": 30598,
+      "name": "Wings of Aesthir",
+      "released_at": "2008-09-22",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.06"
+      }
+    },
+    {
+      "mtgo_id": 45682,
+      "name": "Mwonvuli Beast Tracker",
+      "released_at": "2012-07-13",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.19",
+        "usd_foil": "0.98",
+        "eur": "0.16",
+        "eur_foil": "0.75",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 87969,
+      "name": "Return to Dust",
+      "released_at": "2021-02-05",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.10",
+        "usd_foil": "",
+        "eur": "0.07",
+        "eur_foil": "",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 107305,
+      "name": "Royal Assassin",
+      "released_at": "2023-01-13",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.49",
+        "usd_foil": "0.92",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 62923,
+      "name": "Shock",
+      "released_at": "2017-01-20",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.04",
+        "usd_foil": "0.23",
+        "eur": "0.02",
+        "eur_foil": "0.52",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 65276,
+      "name": "Walk the Plank",
+      "released_at": "2017-09-29",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.11",
+        "usd_foil": "0.42",
+        "eur": "0.10",
+        "eur_foil": "0.10",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 63381,
+      "name": "Sphinx's Revelation",
+      "released_at": "2017-03-17",
+      "rarity": "mythic",
+      "prices": {
+        "usd": "1.22",
+        "usd_foil": "5.38",
+        "eur": "0.50",
+        "eur_foil": "7.99",
+        "tix": "0.13"
+      }
+    },
+    {
+      "mtgo_id": 58735,
+      "name": "Kor Entanglers",
+      "released_at": "2015-10-02",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.05",
+        "usd_foil": "0.41",
+        "eur": "0.02",
+        "eur_foil": "0.14",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 97897,
+      "name": "The Restoration of Eiganjo // Architect of Restoration",
+      "released_at": "2022-02-20",
+      "rarity": "rare",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.94"
+      }
+    },
+    {
+      "mtgo_id": 57294,
+      "name": "Spread the Sickness",
+      "released_at": "2015-05-22",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.23",
+        "usd_foil": "0.46",
+        "eur": "0.02",
+        "eur_foil": "0.05",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 22118,
+      "name": "Celestial Kirin",
+      "released_at": "2005-06-03",
+      "rarity": "rare",
+      "prices": {
+        "usd": "1.03",
+        "usd_foil": "14.05",
+        "eur": "1.00",
+        "eur_foil": "8.00",
+        "tix": "0.01"
+      }
+    },
+    {
+      "mtgo_id": 70675,
+      "name": "Saheeli's Directive",
+      "released_at": "2018-12-06",
+      "rarity": "rare",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.30"
+      }
+    },
+    {
+      "mtgo_id": 22713,
+      "name": "Festering Goblin",
+      "released_at": "2005-07-29",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.10",
+        "usd_foil": "",
+        "eur": "0.02",
+        "eur_foil": "",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 63950,
+      "name": "Initiate's Companion",
+      "released_at": "2017-04-28",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.05",
+        "usd_foil": "0.42",
+        "eur": "0.08",
+        "eur_foil": "0.15",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 14643,
+      "name": "Tsabo's Assassin",
+      "released_at": "2000-10-02",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.43",
+        "usd_foil": "7.95",
+        "eur": "0.10",
+        "eur_foil": "9.99",
+        "tix": "0.05"
+      }
+    },
+    {
+      "mtgo_id": 110478,
+      "name": "Darksteel Splicer",
+      "released_at": "2023-04-21",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.48",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": ""
+      }
+    },
+    {
+      "mtgo_id": 72776,
+      "name": "Hogaak, Arisen Necropolis",
+      "released_at": "2019-06-14",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.92",
+        "usd_foil": "6.74",
+        "eur": "0.98",
+        "eur_foil": "6.25",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 26009,
+      "name": "Jasmine Boreal",
+      "released_at": "2006-10-06",
+      "rarity": "special",
+      "prices": {
+        "usd": "0.22",
+        "usd_foil": "5.98",
+        "eur": "0.13",
+        "eur_foil": "5.00",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 53005,
+      "name": "Grizzly Fate",
+      "released_at": "2014-06-16",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.06"
+      }
+    },
+    {
+      "mtgo_id": 14707,
+      "name": "Ancient Spring",
+      "released_at": "2000-10-02",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.17",
+        "usd_foil": "4.86",
+        "eur": "0.05",
+        "eur_foil": "5.99",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 98659,
+      "name": "Security Rhox",
+      "released_at": "2022-04-29",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.04",
+        "usd_foil": "0.03",
+        "eur": "0.03",
+        "eur_foil": "0.03",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 13741,
+      "name": "Belbe's Armor",
+      "released_at": "2000-02-14",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.22",
+        "usd_foil": "2.94",
+        "eur": "0.24",
+        "eur_foil": "3.50",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 12979,
+      "name": "Slinking Skirge",
+      "released_at": "1999-06-07",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.10",
+        "usd_foil": "3.97",
+        "eur": "0.04",
+        "eur_foil": "0.99",
+        "tix": "0.09"
+      }
+    },
+    {
+      "mtgo_id": 97498,
+      "name": "Scoured Barrens",
+      "released_at": "2022-02-18",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.08",
+        "usd_foil": "0.18",
+        "eur": "0.07",
+        "eur_foil": "0.13",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 90228,
+      "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
+      "released_at": "2021-05-01",
+      "rarity": "rare",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 65232,
+      "name": "Grim Captain's Call",
+      "released_at": "2017-09-29",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.07",
+        "usd_foil": "0.24",
+        "eur": "0.08",
+        "eur_foil": "0.20",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 115465,
+      "name": "Reassembling Skeleton",
+      "released_at": "2023-08-04",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.12",
+        "usd_foil": "0.26",
+        "eur": "0.18",
+        "eur_foil": "0.22",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 78582,
+      "name": "Enchanted Carriage",
+      "released_at": "2019-10-04",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.08",
+        "usd_foil": "0.22",
+        "eur": "0.07",
+        "eur_foil": "0.05",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 21877,
+      "name": "Floodbringer",
+      "released_at": "2005-02-04",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.17",
+        "usd_foil": "3.93",
+        "eur": "0.02",
+        "eur_foil": "0.29",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 39443,
+      "name": "Phyresis",
+      "released_at": "2011-02-04",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.31",
+        "usd_foil": "12.77",
+        "eur": "0.57",
+        "eur_foil": "6.48",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 64602,
+      "name": "Banewhip Punisher",
+      "released_at": "2017-07-14",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.22",
+        "usd_foil": "0.76",
+        "eur": "0.12",
+        "eur_foil": "0.15",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 52427,
+      "name": "Corpse Traders",
+      "released_at": "2014-03-14",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.08",
+        "usd_foil": "",
+        "eur": "0.19",
+        "eur_foil": "",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 35086,
+      "name": "Zodiac Rabbit",
+      "released_at": "2014-10-17",
+      "rarity": "common",
+      "prices": {
+        "usd": "",
+        "usd_foil": "",
+        "eur": "",
+        "eur_foil": "",
+        "tix": ""
+      }
+    },
+    {
+      "mtgo_id": 54008,
+      "name": "Rite of the Serpent",
+      "released_at": "2014-09-26",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.05",
+        "usd_foil": "0.25",
+        "eur": "0.02",
+        "eur_foil": "0.29",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 55225,
+      "name": "Skullclamp",
+      "released_at": "2014-11-07",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "3.69",
+        "usd_foil": "",
+        "eur": "4.07",
+        "eur_foil": "",
+        "tix": "0.90"
+      }
+    },
+    {
+      "mtgo_id": 21815,
+      "name": "Skullmane Baku",
+      "released_at": "2005-02-04",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.09",
+        "usd_foil": "0.15",
+        "eur": "0.05",
+        "eur_foil": "0.10",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 16795,
+      "name": "Infected Vermin",
+      "released_at": "2001-10-01",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.54",
+        "usd_foil": "11.49",
+        "eur": "0.28",
+        "eur_foil": "0.99",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 88999,
+      "name": "Venerable Warsinger",
+      "released_at": "2021-04-23",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.12",
+        "usd_foil": "0.26",
+        "eur": "0.44",
+        "eur_foil": "0.25",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 19195,
+      "name": "Murderous Betrayal",
+      "released_at": "2003-07-28",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.13",
+        "usd_foil": "",
+        "eur": "0.57",
+        "eur_foil": "",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 88003,
+      "name": "Eyeblight Massacre",
+      "released_at": "2021-02-05",
+      "rarity": "uncommon",
+      "prices": {
+        "usd": "0.08",
+        "usd_foil": "",
+        "eur": "0.09",
+        "eur_foil": "",
+        "tix": "0.04"
+      }
+    },
+    {
+      "mtgo_id": 13445,
+      "name": "Saprazzan Skerry",
+      "released_at": "1999-10-04",
+      "rarity": "common",
+      "prices": {
+        "usd": "3.27",
+        "usd_foil": "38.66",
+        "eur": "5.80",
+        "eur_foil": "24.00",
+        "tix": "1.39"
+      }
+    },
+    {
+      "mtgo_id": 31917,
+      "name": "Sphinx Summoner",
+      "released_at": "2009-02-06",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.32",
+        "usd_foil": "2.70",
+        "eur": "0.10",
+        "eur_foil": "1.13",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 19115,
+      "name": "Worship",
+      "released_at": "2003-07-28",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.70",
+        "usd_foil": "",
+        "eur": "0.90",
+        "eur_foil": "",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 65226,
+      "name": "Duress",
+      "released_at": "2017-09-29",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.05",
+        "usd_foil": "0.31",
+        "eur": "0.02",
+        "eur_foil": "0.48",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 36640,
+      "name": "Flame Slash",
+      "released_at": "2010-04-23",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.28",
+        "usd_foil": "11.92",
+        "eur": "0.30",
+        "eur_foil": "9.00",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 58435,
+      "name": "Touch of the Void",
+      "released_at": "2015-10-02",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.03",
+        "usd_foil": "0.24",
+        "eur": "0.02",
+        "eur_foil": "0.15",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 108896,
+      "name": "Danitha, New Benalia's Light",
+      "released_at": "2023-05-12",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.42",
+        "usd_foil": "0.32",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 71500,
+      "name": "Warrant // Warden",
+      "released_at": "2019-01-25",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.09",
+        "usd_foil": "0.51",
+        "eur": "0.10",
+        "eur_foil": "0.49",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 55500,
+      "name": "Lightning Shrieker",
+      "released_at": "2015-01-23",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.04",
+        "usd_foil": "0.34",
+        "eur": "0.15",
+        "eur_foil": "0.13",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 24551,
+      "name": "Diamond Faerie",
+      "released_at": "2006-07-21",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.55",
+        "usd_foil": "9.99",
+        "eur": "0.26",
+        "eur_foil": "1.00",
+        "tix": "0.02"
+      }
+    },
+    {
+      "mtgo_id": 105210,
+      "name": "Titania, Nature's Force",
+      "released_at": "2022-11-18",
+      "rarity": "mythic",
+      "prices": {
+        "usd": "8.49",
+        "usd_foil": "10.16",
+        "eur": "",
+        "eur_foil": "",
+        "tix": "2.17"
+      }
+    },
+    {
+      "mtgo_id": 110222,
+      "name": "Blighted Burgeoning",
+      "released_at": "2023-04-21",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.03",
+        "usd_foil": "0.04",
+        "eur": "0.06",
+        "eur_foil": "0.16",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 83155,
+      "name": "Deadly Alliance",
+      "released_at": "2020-09-25",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.02",
+        "usd_foil": "0.08",
+        "eur": "0.17",
+        "eur_foil": "0.07",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 57914,
+      "name": "Deep-Sea Terror",
+      "released_at": "2015-07-17",
+      "rarity": "common",
+      "prices": {
+        "usd": "0.03",
+        "usd_foil": "0.24",
+        "eur": "0.05",
+        "eur_foil": "0.14",
+        "tix": "0.03"
+      }
+    },
+    {
+      "mtgo_id": 26858,
+      "name": "Steamflogger Boss",
+      "released_at": "2007-05-04",
+      "rarity": "rare",
+      "prices": {
+        "usd": "0.22",
+        "usd_foil": "10.86",
+        "eur": "0.15",
+        "eur_foil": "6.59",
+        "tix": "0.01"
+      }
+    }
+]

--- a/test/test-data/scryfall/default-cards-small-87objs-50cards.json
+++ b/test/test-data/scryfall/default-cards-small-87objs-50cards.json
@@ -1,0 +1,11399 @@
+[
+  {
+    "object": "card",
+    "id": "0000579f-7b35-4ed3-b44c-db2a538066fe",
+    "oracle_id": "44623693-51d6-49ad-8cd7-140505caf02f",
+    "multiverse_ids": [
+      109722
+    ],
+    "mtgo_id": 25527,
+    "mtgo_foil_id": 25528,
+    "tcgplayer_id": 14240,
+    "cardmarket_id": 13850,
+    "name": "Fury Sliver",
+    "lang": "en",
+    "released_at": "2006-10-06",
+    "uri": "https://api.scryfall.com/cards/0000579f-7b35-4ed3-b44c-db2a538066fe",
+    "scryfall_uri": "https://scryfall.com/card/tsp/157/fury-sliver?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1562894979",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1562894979",
+      "large": "https://cards.scryfall.io/large/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1562894979",
+      "png": "https://cards.scryfall.io/png/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.png?1562894979",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1562894979",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1562894979"
+    },
+    "mana_cost": "{5}{R}",
+    "cmc": 6,
+    "type_line": "Creature — Sliver",
+    "oracle_text": "All Sliver creatures have double strike.",
+    "power": "3",
+    "toughness": "3",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "c1d109bc-ffd8-428f-8d7d-3f8d7e648046",
+    "set": "tsp",
+    "set_name": "Time Spiral",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/c1d109bc-ffd8-428f-8d7d-3f8d7e648046",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Atsp&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/tsp?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0000579f-7b35-4ed3-b44c-db2a538066fe/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A44623693-51d6-49ad-8cd7-140505caf02f&unique=prints",
+    "collector_number": "157",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"A rift opened, and our arrows were abruptly stilled. To move was to push the world. But the sliver's claw still twitched, red wounds appeared in Thed's chest, and ribbons of blood hung in the air.\"\n—Adom Capashen, Benalish hero",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Paolo Parente",
+    "artist_ids": [
+      "d48dd097-720d-476a-8722-6a02854ae28b"
+    ],
+    "illustration_id": "2fcca987-364c-4738-a75b-099d8a26d614",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 6343,
+    "penny_rank": 11346,
+    "prices": {
+      "usd": "0.47",
+      "usd_foil": "4.48",
+      "usd_etched": null,
+      "eur": "0.20",
+      "eur_foil": "0.50",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=109722",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Fury+Sliver&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Fury+Sliver&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Fury+Sliver"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/14240?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Fury+Sliver&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/25527?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00006596-1166-4a79-8443-ca9f82e6db4e",
+    "oracle_id": "8ae3562f-28b7-4462-96ed-be0cf7052ccc",
+    "multiverse_ids": [
+      189637
+    ],
+    "mtgo_id": 34586,
+    "mtgo_foil_id": 34587,
+    "tcgplayer_id": 33347,
+    "cardmarket_id": 21851,
+    "name": "Kor Outfitter",
+    "lang": "en",
+    "released_at": "2009-10-02",
+    "uri": "https://api.scryfall.com/cards/00006596-1166-4a79-8443-ca9f82e6db4e",
+    "scryfall_uri": "https://scryfall.com/card/zen/21/kor-outfitter?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1562609251",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1562609251",
+      "large": "https://cards.scryfall.io/large/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1562609251",
+      "png": "https://cards.scryfall.io/png/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.png?1562609251",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1562609251",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1562609251"
+    },
+    "mana_cost": "{W}{W}",
+    "cmc": 2,
+    "type_line": "Creature — Kor Soldier",
+    "oracle_text": "When Kor Outfitter enters the battlefield, you may attach target Equipment you control to target creature you control.",
+    "power": "2",
+    "toughness": "2",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "eb16a2bd-a218-4e4e-8339-4aa1afc0c8d2",
+    "set": "zen",
+    "set_name": "Zendikar",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/eb16a2bd-a218-4e4e-8339-4aa1afc0c8d2",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Azen&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/zen?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00006596-1166-4a79-8443-ca9f82e6db4e/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A8ae3562f-28b7-4462-96ed-be0cf7052ccc&unique=prints",
+    "collector_number": "21",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"We take only what we need to survive. Believe me, you will need this.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Kieran Yanner",
+    "artist_ids": [
+      "aa7e89ed-d294-4633-9057-ce04dacfcfa4"
+    ],
+    "illustration_id": "de0310d1-e97f-46e0-bc16-c980c2adedee",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 15627,
+    "penny_rank": 5098,
+    "prices": {
+      "usd": "0.25",
+      "usd_foil": "7.87",
+      "usd_etched": null,
+      "eur": "0.11",
+      "eur_foil": "2.20",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=189637",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Kor+Outfitter&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Kor+Outfitter&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Kor+Outfitter"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/33347?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Kor+Outfitter&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/34586?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0000a54c-a511-4925-92dc-01b937f9afad",
+    "oracle_id": "dc4e2134-f0c2-49aa-9ea3-ebf83af1445c",
+    "multiverse_ids": [],
+    "tcgplayer_id": 98659,
+    "name": "Spirit",
+    "lang": "en",
+    "released_at": "2015-05-22",
+    "uri": "https://api.scryfall.com/cards/0000a54c-a511-4925-92dc-01b937f9afad",
+    "scryfall_uri": "https://scryfall.com/card/tmm2/5/spirit?utm_source=api",
+    "layout": "token",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1562701869",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1562701869",
+      "large": "https://cards.scryfall.io/large/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1562701869",
+      "png": "https://cards.scryfall.io/png/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.png?1562701869",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1562701869",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1562701869"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Token Creature — Spirit",
+    "oracle_text": "Flying",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [
+      "Flying"
+    ],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "4d8542f6-ee34-42c6-acd5-07b0c7cc2f63",
+        "component": "combo_piece",
+        "name": "Funeral Pyre",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/4d8542f6-ee34-42c6-acd5-07b0c7cc2f63"
+      },
+      {
+        "object": "related_card",
+        "id": "66210a3f-010b-4a9b-a08f-97d3ca962b0c",
+        "component": "combo_piece",
+        "name": "Haunted Dead",
+        "type_line": "Creature — Zombie",
+        "uri": "https://api.scryfall.com/cards/66210a3f-010b-4a9b-a08f-97d3ca962b0c"
+      },
+      {
+        "object": "related_card",
+        "id": "d333e35c-ca90-4aaa-950a-48b5623c31a6",
+        "component": "combo_piece",
+        "name": "Blessed Defiance",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/d333e35c-ca90-4aaa-950a-48b5623c31a6"
+      },
+      {
+        "object": "related_card",
+        "id": "f0ad0796-0357-4e74-9d65-c7761a3f223c",
+        "component": "combo_piece",
+        "name": "Slayer's Plate",
+        "type_line": "Artifact — Equipment",
+        "uri": "https://api.scryfall.com/cards/f0ad0796-0357-4e74-9d65-c7761a3f223c"
+      },
+      {
+        "object": "related_card",
+        "id": "f11908e8-8c85-4eb7-b29d-b97712be42ee",
+        "component": "combo_piece",
+        "name": "Lingering Souls",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/f11908e8-8c85-4eb7-b29d-b97712be42ee"
+      },
+      {
+        "object": "related_card",
+        "id": "17be11f2-f2db-40c4-8fc1-2ed7173f9a1a",
+        "component": "combo_piece",
+        "name": "Staff of the Storyteller",
+        "type_line": "Artifact",
+        "uri": "https://api.scryfall.com/cards/17be11f2-f2db-40c4-8fc1-2ed7173f9a1a"
+      },
+      {
+        "object": "related_card",
+        "id": "8a840ee7-5728-4b1b-92ac-54612e5397b3",
+        "component": "combo_piece",
+        "name": "Gallows at Willow Hill",
+        "type_line": "Artifact",
+        "uri": "https://api.scryfall.com/cards/8a840ee7-5728-4b1b-92ac-54612e5397b3"
+      },
+      {
+        "object": "related_card",
+        "id": "dd4287fc-3e16-473f-818c-9f4d57d03125",
+        "component": "combo_piece",
+        "name": "Kaya the Inexorable",
+        "type_line": "Legendary Planeswalker — Kaya",
+        "uri": "https://api.scryfall.com/cards/dd4287fc-3e16-473f-818c-9f4d57d03125"
+      },
+      {
+        "object": "related_card",
+        "id": "a4861c8d-5e4a-4c4b-854c-410aad2d49cb",
+        "component": "combo_piece",
+        "name": "Nearheath Chaplain",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/a4861c8d-5e4a-4c4b-854c-410aad2d49cb"
+      },
+      {
+        "object": "related_card",
+        "id": "6a780abd-f276-40d3-b2af-d2e47d858d3d",
+        "component": "combo_piece",
+        "name": "Oath of the Grey Host",
+        "type_line": "Enchantment — Saga",
+        "uri": "https://api.scryfall.com/cards/6a780abd-f276-40d3-b2af-d2e47d858d3d"
+      },
+      {
+        "object": "related_card",
+        "id": "e6d09b61-5529-4906-91a6-5259fb180442",
+        "component": "combo_piece",
+        "name": "Ethereal Investigator",
+        "type_line": "Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/e6d09b61-5529-4906-91a6-5259fb180442"
+      },
+      {
+        "object": "related_card",
+        "id": "a3f29cbb-d802-4085-a236-86775764bc9e",
+        "component": "combo_piece",
+        "name": "Whispering Wizard",
+        "type_line": "Creature — Human Wizard",
+        "uri": "https://api.scryfall.com/cards/a3f29cbb-d802-4085-a236-86775764bc9e"
+      },
+      {
+        "object": "related_card",
+        "id": "9964629e-d79e-46e4-b3fd-e7d1759cbc60",
+        "component": "combo_piece",
+        "name": "Spectral Procession",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/9964629e-d79e-46e4-b3fd-e7d1759cbc60"
+      },
+      {
+        "object": "related_card",
+        "id": "0df01c9a-5d2c-4391-99a3-f10e404b7133",
+        "component": "combo_piece",
+        "name": "Abzan Ascendancy",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/0df01c9a-5d2c-4391-99a3-f10e404b7133"
+      },
+      {
+        "object": "related_card",
+        "id": "d080c35d-f2c6-4f4e-8f7c-305b319d4cde",
+        "component": "combo_piece",
+        "name": "Benevolent Offering",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/d080c35d-f2c6-4f4e-8f7c-305b319d4cde"
+      },
+      {
+        "object": "related_card",
+        "id": "6a7fb95f-744a-4fe9-a117-0a9d16938793",
+        "component": "combo_piece",
+        "name": "King of the Oathbreakers",
+        "type_line": "Legendary Creature — Spirit Noble",
+        "uri": "https://api.scryfall.com/cards/6a7fb95f-744a-4fe9-a117-0a9d16938793"
+      },
+      {
+        "object": "related_card",
+        "id": "1b302947-5d66-425d-b67e-bf1d5846d490",
+        "component": "combo_piece",
+        "name": "Nurturing Presence",
+        "type_line": "Enchantment — Aura",
+        "uri": "https://api.scryfall.com/cards/1b302947-5d66-425d-b67e-bf1d5846d490"
+      },
+      {
+        "object": "related_card",
+        "id": "d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f",
+        "component": "combo_piece",
+        "name": "Triplicate Spirits",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f"
+      },
+      {
+        "object": "related_card",
+        "id": "258946f2-294a-4ddf-be91-9ff4c94e4bdb",
+        "component": "combo_piece",
+        "name": "Afterlife",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/258946f2-294a-4ddf-be91-9ff4c94e4bdb"
+      },
+      {
+        "object": "related_card",
+        "id": "020dc072-96e2-4923-b9c9-1791a0732c29",
+        "component": "combo_piece",
+        "name": "Field of Souls",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/020dc072-96e2-4923-b9c9-1791a0732c29"
+      },
+      {
+        "object": "related_card",
+        "id": "fbbbbbf7-eaae-462e-a8eb-7f6a97703600",
+        "component": "combo_piece",
+        "name": "Kirtar's Wrath",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/fbbbbbf7-eaae-462e-a8eb-7f6a97703600"
+      },
+      {
+        "object": "related_card",
+        "id": "df8bbd04-981e-45ec-a835-7237350630cf",
+        "component": "combo_piece",
+        "name": "Moorland Haunt",
+        "type_line": "Land",
+        "uri": "https://api.scryfall.com/cards/df8bbd04-981e-45ec-a835-7237350630cf"
+      },
+      {
+        "object": "related_card",
+        "id": "dc8037d5-79fa-47e3-9d3b-eb29643ecae7",
+        "component": "combo_piece",
+        "name": "Hallowed Spiritkeeper",
+        "type_line": "Creature — Avatar",
+        "uri": "https://api.scryfall.com/cards/dc8037d5-79fa-47e3-9d3b-eb29643ecae7"
+      },
+      {
+        "object": "related_card",
+        "id": "ddcb90f4-82c0-412c-9e90-9fffc8c5df10",
+        "component": "combo_piece",
+        "name": "Requiem Angel",
+        "type_line": "Creature — Angel",
+        "uri": "https://api.scryfall.com/cards/ddcb90f4-82c0-412c-9e90-9fffc8c5df10"
+      },
+      {
+        "object": "related_card",
+        "id": "7618aa2d-d5b3-41e6-978f-2c8292f7f896",
+        "component": "combo_piece",
+        "name": "Spectral Reserves",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/7618aa2d-d5b3-41e6-978f-2c8292f7f896"
+      },
+      {
+        "object": "related_card",
+        "id": "43227caf-f902-46b4-936f-125d879eb54a",
+        "component": "combo_piece",
+        "name": "Mausoleum Guard",
+        "type_line": "Creature — Human Scout",
+        "uri": "https://api.scryfall.com/cards/43227caf-f902-46b4-936f-125d879eb54a"
+      },
+      {
+        "object": "related_card",
+        "id": "add661e7-b337-44e4-9614-ca958e20e86f",
+        "component": "combo_piece",
+        "name": "Occult Epiphany",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/add661e7-b337-44e4-9614-ca958e20e86f"
+      },
+      {
+        "object": "related_card",
+        "id": "eb405cb1-3643-417c-b27f-4b6c3dca3a96",
+        "component": "combo_piece",
+        "name": "Hanged Executioner",
+        "type_line": "Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/eb405cb1-3643-417c-b27f-4b6c3dca3a96"
+      },
+      {
+        "object": "related_card",
+        "id": "fb911c45-9f6a-4cf2-aa1e-4361cf170c17",
+        "component": "combo_piece",
+        "name": "Millicent, Restless Revenant",
+        "type_line": "Legendary Creature — Spirit Soldier",
+        "uri": "https://api.scryfall.com/cards/fb911c45-9f6a-4cf2-aa1e-4361cf170c17"
+      },
+      {
+        "object": "related_card",
+        "id": "f01e857d-cc78-4364-9f31-6879d4ec74e1",
+        "component": "combo_piece",
+        "name": "Kykar, Wind's Fury",
+        "type_line": "Legendary Creature — Bird Wizard",
+        "uri": "https://api.scryfall.com/cards/f01e857d-cc78-4364-9f31-6879d4ec74e1"
+      },
+      {
+        "object": "related_card",
+        "id": "6fbc9abd-8719-4cea-8bf4-1a3d78e3f00b",
+        "component": "combo_piece",
+        "name": "Priest of the Blessed Graf",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/6fbc9abd-8719-4cea-8bf4-1a3d78e3f00b"
+      },
+      {
+        "object": "related_card",
+        "id": "e732cdf6-b127-4c6b-aa8a-109ddafa0aef",
+        "component": "combo_piece",
+        "name": "Thalisse, Reverent Medium",
+        "type_line": "Legendary Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/e732cdf6-b127-4c6b-aa8a-109ddafa0aef"
+      },
+      {
+        "object": "related_card",
+        "id": "c9786c13-b57a-46be-bbbe-e17333defbd4",
+        "component": "combo_piece",
+        "name": "Sanctifier of Souls",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/c9786c13-b57a-46be-bbbe-e17333defbd4"
+      },
+      {
+        "object": "related_card",
+        "id": "4716ede8-d08e-426b-aed3-8cf36c9b51c9",
+        "component": "combo_piece",
+        "name": "Teysa, Orzhov Scion",
+        "type_line": "Legendary Creature — Human Advisor",
+        "uri": "https://api.scryfall.com/cards/4716ede8-d08e-426b-aed3-8cf36c9b51c9"
+      },
+      {
+        "object": "related_card",
+        "id": "219dd7c5-0d8f-46a2-9181-3ed30d489397",
+        "component": "combo_piece",
+        "name": "Avacyn's Collar",
+        "type_line": "Artifact — Equipment",
+        "uri": "https://api.scryfall.com/cards/219dd7c5-0d8f-46a2-9181-3ed30d489397"
+      },
+      {
+        "object": "related_card",
+        "id": "83632e73-be3f-43fc-932f-45cb1af4f8fb",
+        "component": "combo_piece",
+        "name": "Valor of the Worthy",
+        "type_line": "Enchantment — Aura",
+        "uri": "https://api.scryfall.com/cards/83632e73-be3f-43fc-932f-45cb1af4f8fb"
+      },
+      {
+        "object": "related_card",
+        "id": "4205f8f8-7b18-4999-ac51-860fab376d79",
+        "component": "combo_piece",
+        "name": "Brine Comber // Brinebound Gift",
+        "type_line": "Creature — Spirit // Enchantment — Aura",
+        "uri": "https://api.scryfall.com/cards/4205f8f8-7b18-4999-ac51-860fab376d79"
+      },
+      {
+        "object": "related_card",
+        "id": "c3ac419f-7630-48c7-9039-88ce28898b6d",
+        "component": "combo_piece",
+        "name": "Luminous Angel",
+        "type_line": "Creature — Angel",
+        "uri": "https://api.scryfall.com/cards/c3ac419f-7630-48c7-9039-88ce28898b6d"
+      },
+      {
+        "object": "related_card",
+        "id": "29bf245f-e8e0-4d32-8cd7-06d832609910",
+        "component": "combo_piece",
+        "name": "Seize the Soul",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/29bf245f-e8e0-4d32-8cd7-06d832609910"
+      },
+      {
+        "object": "related_card",
+        "id": "3a79a435-9b58-4bcd-8544-79d9a71d85a2",
+        "component": "combo_piece",
+        "name": "Heron-Blessed Geist",
+        "type_line": "Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/3a79a435-9b58-4bcd-8544-79d9a71d85a2"
+      },
+      {
+        "object": "related_card",
+        "id": "9c5b6837-2381-4563-861c-73ef3b5341cd",
+        "component": "combo_piece",
+        "name": "Doomed Traveler",
+        "type_line": "Creature — Human Soldier",
+        "uri": "https://api.scryfall.com/cards/9c5b6837-2381-4563-861c-73ef3b5341cd"
+      },
+      {
+        "object": "related_card",
+        "id": "eddc09d1-63de-4791-b654-31b354032c54",
+        "component": "combo_piece",
+        "name": "Midnight Haunting",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/eddc09d1-63de-4791-b654-31b354032c54"
+      },
+      {
+        "object": "related_card",
+        "id": "a36ab7fa-7b90-4ccc-8fe9-93453f10a237",
+        "component": "combo_piece",
+        "name": "Drogskol Cavalry",
+        "type_line": "Creature — Spirit Knight",
+        "uri": "https://api.scryfall.com/cards/a36ab7fa-7b90-4ccc-8fe9-93453f10a237"
+      },
+      {
+        "object": "related_card",
+        "id": "9b0f860c-029c-4856-a999-05b3306c7d46",
+        "component": "combo_piece",
+        "name": "Spirit Cairn",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/9b0f860c-029c-4856-a999-05b3306c7d46"
+      },
+      {
+        "object": "related_card",
+        "id": "c369d381-b48e-43cf-a032-8bcb120f443e",
+        "component": "combo_piece",
+        "name": "Bishop of Wings",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/c369d381-b48e-43cf-a032-8bcb120f443e"
+      },
+      {
+        "object": "related_card",
+        "id": "ef2bb440-87b7-4d3d-9b37-2f1ebaca4b3f",
+        "component": "combo_piece",
+        "name": "Twilight Drover",
+        "type_line": "Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/ef2bb440-87b7-4d3d-9b37-2f1ebaca4b3f"
+      },
+      {
+        "object": "related_card",
+        "id": "97c4288f-7d22-4a5f-9b2e-d67734d9a6e7",
+        "component": "combo_piece",
+        "name": "Path of the Ghosthunter",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/97c4288f-7d22-4a5f-9b2e-d67734d9a6e7"
+      },
+      {
+        "object": "related_card",
+        "id": "ec0984b2-bed6-41b1-9087-2cfd16749037",
+        "component": "combo_piece",
+        "name": "Shadow Summoning",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/ec0984b2-bed6-41b1-9087-2cfd16749037"
+      },
+      {
+        "object": "related_card",
+        "id": "f07dd0f1-b80b-4af0-ae76-907ec55ec7d5",
+        "component": "combo_piece",
+        "name": "March of Souls",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/f07dd0f1-b80b-4af0-ae76-907ec55ec7d5"
+      },
+      {
+        "object": "related_card",
+        "id": "87673b63-cacb-43b3-8723-924a7d5aed0c",
+        "component": "combo_piece",
+        "name": "Confront the Assault",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/87673b63-cacb-43b3-8723-924a7d5aed0c"
+      },
+      {
+        "object": "related_card",
+        "id": "f4051020-688c-473a-9a08-b62f0fd75675",
+        "component": "combo_piece",
+        "name": "Vessel of Ephemera",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/f4051020-688c-473a-9a08-b62f0fd75675"
+      },
+      {
+        "object": "related_card",
+        "id": "bf6570e3-f245-4556-89b4-a48f26b6dc4f",
+        "component": "combo_piece",
+        "name": "Dauntless Cathar",
+        "type_line": "Creature — Human Soldier",
+        "uri": "https://api.scryfall.com/cards/bf6570e3-f245-4556-89b4-a48f26b6dc4f"
+      },
+      {
+        "object": "related_card",
+        "id": "1c8c41dd-8551-4ce8-a9be-9b9f65718852",
+        "component": "combo_piece",
+        "name": "Ranar the Ever-Watchful",
+        "type_line": "Legendary Creature — Spirit Warrior",
+        "uri": "https://api.scryfall.com/cards/1c8c41dd-8551-4ce8-a9be-9b9f65718852"
+      },
+      {
+        "object": "related_card",
+        "id": "6a0dd7ba-673e-4f69-8cd3-806784501dc2",
+        "component": "combo_piece",
+        "name": "Custodi Soulbinders",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/6a0dd7ba-673e-4f69-8cd3-806784501dc2"
+      },
+      {
+        "object": "related_card",
+        "id": "3fdf5020-ea97-4f95-a096-cb5688dad2e2",
+        "component": "combo_piece",
+        "name": "Alharu, Solemn Ritualist",
+        "type_line": "Legendary Creature — Human Monk",
+        "uri": "https://api.scryfall.com/cards/3fdf5020-ea97-4f95-a096-cb5688dad2e2"
+      },
+      {
+        "object": "related_card",
+        "id": "0000a54c-a511-4925-92dc-01b937f9afad",
+        "component": "token",
+        "name": "Spirit",
+        "type_line": "Token Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/0000a54c-a511-4925-92dc-01b937f9afad"
+      },
+      {
+        "object": "related_card",
+        "id": "86a4c348-1012-4339-960a-c7bc7fd84fbb",
+        "component": "combo_piece",
+        "name": "Clarion Spirit",
+        "type_line": "Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/86a4c348-1012-4339-960a-c7bc7fd84fbb"
+      },
+      {
+        "object": "related_card",
+        "id": "9135b501-82be-43cb-9aa5-9cf08789c636",
+        "component": "combo_piece",
+        "name": "Kaya, Geist Hunter",
+        "type_line": "Legendary Planeswalker — Kaya",
+        "uri": "https://api.scryfall.com/cards/9135b501-82be-43cb-9aa5-9cf08789c636"
+      },
+      {
+        "object": "related_card",
+        "id": "05860b72-fb1b-44d8-9275-12863724a9ef",
+        "component": "combo_piece",
+        "name": "Not Forgotten",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/05860b72-fb1b-44d8-9275-12863724a9ef"
+      },
+      {
+        "object": "related_card",
+        "id": "4d09ef1d-3552-43a3-91c7-0d14c0f06780",
+        "component": "combo_piece",
+        "name": "Geist-Honored Monk",
+        "type_line": "Creature — Human Monk",
+        "uri": "https://api.scryfall.com/cards/4d09ef1d-3552-43a3-91c7-0d14c0f06780"
+      },
+      {
+        "object": "related_card",
+        "id": "1b7a47cc-9311-4f92-b19c-8956db5f2b5f",
+        "component": "combo_piece",
+        "name": "Rousing of Souls",
+        "type_line": "Sorcery",
+        "uri": "https://api.scryfall.com/cards/1b7a47cc-9311-4f92-b19c-8956db5f2b5f"
+      },
+      {
+        "object": "related_card",
+        "id": "ed36c685-df55-4d62-99ba-9ad1cb7547f7",
+        "component": "combo_piece",
+        "name": "Andúril, Flame of the West",
+        "type_line": "Legendary Artifact — Equipment",
+        "uri": "https://api.scryfall.com/cards/ed36c685-df55-4d62-99ba-9ad1cb7547f7"
+      },
+      {
+        "object": "related_card",
+        "id": "b3e98964-e1ce-40ba-be0d-27e39e724074",
+        "component": "combo_piece",
+        "name": "Haunted Library",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/b3e98964-e1ce-40ba-be0d-27e39e724074"
+      },
+      {
+        "object": "related_card",
+        "id": "c342e1da-7ab9-4e29-96e6-77d820a45ede",
+        "component": "combo_piece",
+        "name": "Elgaud Inquisitor",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/c342e1da-7ab9-4e29-96e6-77d820a45ede"
+      },
+      {
+        "object": "related_card",
+        "id": "4531482d-9238-40de-957e-61beb5700330",
+        "component": "combo_piece",
+        "name": "Thalia's Geistcaller",
+        "type_line": "Creature — Human Cleric",
+        "uri": "https://api.scryfall.com/cards/4531482d-9238-40de-957e-61beb5700330"
+      },
+      {
+        "object": "related_card",
+        "id": "cc5fa496-a830-4031-a19a-d6467d074ad1",
+        "component": "combo_piece",
+        "name": "Emissary of the Sleepless",
+        "type_line": "Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/cc5fa496-a830-4031-a19a-d6467d074ad1"
+      },
+      {
+        "object": "related_card",
+        "id": "aa2a3aaa-e78a-48cc-b7d3-7f65e467054c",
+        "component": "combo_piece",
+        "name": "Spirit Bonds",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/aa2a3aaa-e78a-48cc-b7d3-7f65e467054c"
+      },
+      {
+        "object": "related_card",
+        "id": "318ce4ef-38bd-4360-895f-457587164197",
+        "component": "combo_piece",
+        "name": "Transluminant",
+        "type_line": "Creature — Dryad Shaman",
+        "uri": "https://api.scryfall.com/cards/318ce4ef-38bd-4360-895f-457587164197"
+      },
+      {
+        "object": "related_card",
+        "id": "dc098d5b-0cdb-422f-8bd2-7afd81a7b7c3",
+        "component": "combo_piece",
+        "name": "Court of Grace",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/dc098d5b-0cdb-422f-8bd2-7afd81a7b7c3"
+      },
+      {
+        "object": "related_card",
+        "id": "b34a7501-4afc-4467-b0d6-b32d7657064e",
+        "component": "combo_piece",
+        "name": "Sandsteppe Outcast",
+        "type_line": "Creature — Human Warrior",
+        "uri": "https://api.scryfall.com/cards/b34a7501-4afc-4467-b0d6-b32d7657064e"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "not_legal",
+      "pauper": "not_legal",
+      "vintage": "not_legal",
+      "penny": "not_legal",
+      "commander": "not_legal",
+      "oathbreaker": "not_legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "not_legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "f7aa47c6-c1e2-4de5-9a68-4406d84bd6bb",
+    "set": "tmm2",
+    "set_name": "Modern Masters 2015 Tokens",
+    "set_type": "token",
+    "set_uri": "https://api.scryfall.com/sets/f7aa47c6-c1e2-4de5-9a68-4406d84bd6bb",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Atmm2&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/tmm2?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0000a54c-a511-4925-92dc-01b937f9afad/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Adc4e2134-f0c2-49aa-9ea3-ebf83af1445c&unique=prints",
+    "collector_number": "5",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Mike Sass",
+    "artist_ids": [
+      "155bc2cb-038d-4b1f-9990-6178db1d1a21"
+    ],
+    "illustration_id": "1dbe0618-dd47-442c-acf6-ac5e4b136e5a",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "promo_types": [
+      "setpromo"
+    ],
+    "prices": {
+      "usd": "0.10",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Spirit&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Spirit&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Spirit"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/98659?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Spirit&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Spirit&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0000cd57-91fe-411f-b798-646e965eec37",
+    "oracle_id": "9f0d82ae-38bf-45d8-8cda-982b6ead1d72",
+    "multiverse_ids": [
+      435231
+    ],
+    "mtgo_id": 65170,
+    "mtgo_foil_id": 65171,
+    "arena_id": 66119,
+    "tcgplayer_id": 145764,
+    "cardmarket_id": 301766,
+    "name": "Siren Lookout",
+    "lang": "en",
+    "released_at": "2017-09-29",
+    "uri": "https://api.scryfall.com/cards/0000cd57-91fe-411f-b798-646e965eec37",
+    "scryfall_uri": "https://scryfall.com/card/xln/78/siren-lookout?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1562549609",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1562549609",
+      "large": "https://cards.scryfall.io/large/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1562549609",
+      "png": "https://cards.scryfall.io/png/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.png?1562549609",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1562549609",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1562549609"
+    },
+    "mana_cost": "{2}{U}",
+    "cmc": 3,
+    "type_line": "Creature — Siren Pirate",
+    "oracle_text": "Flying\nWhen Siren Lookout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "power": "1",
+    "toughness": "2",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [
+      "Flying",
+      "Explore"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "fe0dad85-54bc-4151-9200-d68da84dd0f2",
+    "set": "xln",
+    "set_name": "Ixalan",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/fe0dad85-54bc-4151-9200-d68da84dd0f2",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Axln&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/xln?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0000cd57-91fe-411f-b798-646e965eec37/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A9f0d82ae-38bf-45d8-8cda-982b6ead1d72&unique=prints",
+    "collector_number": "78",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Chris Rallis",
+    "artist_ids": [
+      "a8e7b854-b15a-421a-b66d-6e68187ae285"
+    ],
+    "illustration_id": "e0a40a54-9216-4c86-b9e3-daed04abc310",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 14052,
+    "penny_rank": 8675,
+    "prices": {
+      "usd": "0.03",
+      "usd_foil": "0.22",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.05",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=435231",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Siren+Lookout&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Siren+Lookout&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Siren+Lookout"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/145764?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Siren+Lookout&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/65170?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00012bd8-ed68-4978-a22d-f450c8a6e048",
+    "oracle_id": "5aa12aff-db3c-4be5-822b-3afdf536b33e",
+    "multiverse_ids": [
+      1278
+    ],
+    "tcgplayer_id": 1623,
+    "cardmarket_id": 5664,
+    "name": "Web",
+    "lang": "en",
+    "released_at": "1994-04-01",
+    "uri": "https://api.scryfall.com/cards/00012bd8-ed68-4978-a22d-f450c8a6e048",
+    "scryfall_uri": "https://scryfall.com/card/3ed/229/web?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00012bd8-ed68-4978-a22d-f450c8a6e048.jpg?1559596693",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00012bd8-ed68-4978-a22d-f450c8a6e048.jpg?1559596693",
+      "large": "https://cards.scryfall.io/large/front/0/0/00012bd8-ed68-4978-a22d-f450c8a6e048.jpg?1559596693",
+      "png": "https://cards.scryfall.io/png/front/0/0/00012bd8-ed68-4978-a22d-f450c8a6e048.png?1559596693",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00012bd8-ed68-4978-a22d-f450c8a6e048.jpg?1559596693",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00012bd8-ed68-4978-a22d-f450c8a6e048.jpg?1559596693"
+    },
+    "mana_cost": "{G}",
+    "cmc": 1,
+    "type_line": "Enchantment — Aura",
+    "oracle_text": "Enchant creature (Target a creature as you cast this. This card enters the battlefield attached to that creature.)\nEnchanted creature gets +0/+2 and has reach. (It can block creatures with flying.)",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Enchant"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "45a69797-8adf-468e-a4e1-ba81fd9d66ac",
+    "set": "3ed",
+    "set_name": "Revised Edition",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/45a69797-8adf-468e-a4e1-ba81fd9d66ac",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A3ed&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/3ed?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00012bd8-ed68-4978-a22d-f450c8a6e048/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A5aa12aff-db3c-4be5-822b-3afdf536b33e&unique=prints",
+    "collector_number": "229",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Rob Alexander",
+    "artist_ids": [
+      "35906871-6c78-4ab2-9ed1-e6792c8efb74"
+    ],
+    "illustration_id": "1eac4d23-2b24-4f4a-b73f-25607c13b806",
+    "border_color": "white",
+    "frame": "1993",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 20979,
+    "prices": {
+      "usd": "0.66",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.75",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=1278",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Web&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Web&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Web"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/1623?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Web&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Web&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0001e77a-7fff-49d2-a55c-42f6fdf6db08",
+    "oracle_id": "396b088d-f9af-4ee1-843f-dbe1633f9cc8",
+    "multiverse_ids": [],
+    "mtgo_id": 116428,
+    "arena_id": 86752,
+    "tcgplayer_id": 513888,
+    "cardmarket_id": 730003,
+    "name": "Obyra's Attendants // Desperate Parry",
+    "lang": "en",
+    "released_at": "2023-09-08",
+    "uri": "https://api.scryfall.com/cards/0001e77a-7fff-49d2-a55c-42f6fdf6db08",
+    "scryfall_uri": "https://scryfall.com/card/woe/63/obyras-attendants-desperate-parry?utm_source=api",
+    "layout": "adventure",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+      "large": "https://cards.scryfall.io/large/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+      "png": "https://cards.scryfall.io/png/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.png?1692937199",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199"
+    },
+    "mana_cost": "{4}{U} // {1}{U}",
+    "cmc": 5,
+    "type_line": "Creature — Faerie Wizard // Instant — Adventure",
+    "power": "3",
+    "toughness": "4",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [
+      "Flying"
+    ],
+    "card_faces": [
+      {
+        "object": "card_face",
+        "name": "Obyra's Attendants",
+        "mana_cost": "{4}{U}",
+        "type_line": "Creature — Faerie Wizard",
+        "oracle_text": "Flying",
+        "power": "3",
+        "toughness": "4",
+        "flavor_text": "Obyra's devoted servants shrieked as their sleeping mistress slashed at them, unseeing.",
+        "artist": "Andreas Zafiratos",
+        "artist_id": "e2f13a9a-57c5-40de-81d4-3b0723899cdf",
+        "illustration_id": "d1ea5321-62e2-4894-a79f-03b792daf2c8"
+      },
+      {
+        "object": "card_face",
+        "name": "Desperate Parry",
+        "flavor_name": "",
+        "mana_cost": "{1}{U}",
+        "type_line": "Instant — Adventure",
+        "oracle_text": "Target creature gets -4/-0 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+        "artist": "Andreas Zafiratos",
+        "artist_id": "e2f13a9a-57c5-40de-81d4-3b0723899cdf"
+      }
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "arena",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "79139661-13ee-43c4-8bad-a8c069f1a1df",
+    "set": "woe",
+    "set_name": "Wilds of Eldraine",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/79139661-13ee-43c4-8bad-a8c069f1a1df",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Awoe&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/woe?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0001e77a-7fff-49d2-a55c-42f6fdf6db08/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A396b088d-f9af-4ee1-843f-dbe1633f9cc8&unique=prints",
+    "collector_number": "63",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "Obyra's devoted servants shrieked as their sleeping mistress slashed at them, unseeing.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Andreas Zafiratos",
+    "artist_ids": [
+      "e2f13a9a-57c5-40de-81d4-3b0723899cdf"
+    ],
+    "illustration_id": "d1ea5321-62e2-4894-a79f-03b792daf2c8",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 24760,
+    "prices": {
+      "usd": "0.25",
+      "usd_foil": "0.18",
+      "usd_etched": null,
+      "eur": "0.10",
+      "eur_foil": "0.18",
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Obyra%27s+Attendants+%2F%2F+Desperate+Parry&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Obyra%27s+Attendants+%2F%2F+Desperate+Parry&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Obyra%27s+Attendants"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/513888?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Obyra%27s+Attendants&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/116428?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0001f1ef-b957-4a55-b47f-14839cdbab6f",
+    "oracle_id": "ef027846-be81-4959-a6b5-56bd01b1e68a",
+    "multiverse_ids": [
+      472997
+    ],
+    "mtgo_id": 78170,
+    "arena_id": 70182,
+    "tcgplayer_id": 198861,
+    "cardmarket_id": 400134,
+    "name": "Venerable Knight",
+    "lang": "en",
+    "released_at": "2019-10-04",
+    "uri": "https://api.scryfall.com/cards/0001f1ef-b957-4a55-b47f-14839cdbab6f",
+    "scryfall_uri": "https://scryfall.com/card/eld/35/venerable-knight?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1572489814",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1572489814",
+      "large": "https://cards.scryfall.io/large/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1572489814",
+      "png": "https://cards.scryfall.io/png/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.png?1572489814",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1572489814",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1572489814"
+    },
+    "mana_cost": "{W}",
+    "cmc": 1,
+    "type_line": "Creature — Human Knight",
+    "oracle_text": "When Venerable Knight dies, put a +1/+1 counter on target Knight you control.",
+    "power": "2",
+    "toughness": "1",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "a90a7b2f-9dd8-4fc7-9f7d-8ea2797ec782",
+    "set": "eld",
+    "set_name": "Throne of Eldraine",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/a90a7b2f-9dd8-4fc7-9f7d-8ea2797ec782",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aeld&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/eld?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0001f1ef-b957-4a55-b47f-14839cdbab6f/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aef027846-be81-4959-a6b5-56bd01b1e68a&unique=prints",
+    "collector_number": "35",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"May this blade guide you on your great journey, as it did me on mine.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Colin Boyer",
+    "artist_ids": [
+      "9c201dbe-db56-429a-87e6-189ea70c2632"
+    ],
+    "illustration_id": "619c439b-8b4d-4c0c-9f86-9fdae9bd1c25",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 13565,
+    "penny_rank": 1490,
+    "preview": {
+      "source": "Autumn Burchett",
+      "source_uri": "https://twitter.com/AutumnLilyMTG/status/1172207122555293696",
+      "previewed_at": "2019-09-04"
+    },
+    "prices": {
+      "usd": "0.09",
+      "usd_foil": "0.28",
+      "usd_etched": null,
+      "eur": "0.13",
+      "eur_foil": "0.25",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=472997",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Venerable+Knight&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Venerable+Knight&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Venerable+Knight"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/198861?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Venerable+Knight&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/78170?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00020b05-ecb9-4603-8cc1-8cfa7a14befc",
+    "oracle_id": "d96ac790-428b-4a64-8dbd-6baa73eb6210",
+    "multiverse_ids": [
+      394089
+    ],
+    "tcgplayer_id": 95585,
+    "cardmarket_id": 272052,
+    "name": "Wildcall",
+    "lang": "en",
+    "released_at": "2015-01-17",
+    "uri": "https://api.scryfall.com/cards/00020b05-ecb9-4603-8cc1-8cfa7a14befc",
+    "scryfall_uri": "https://scryfall.com/card/ugin/146/wildcall?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00020b05-ecb9-4603-8cc1-8cfa7a14befc.jpg?1562633475",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00020b05-ecb9-4603-8cc1-8cfa7a14befc.jpg?1562633475",
+      "large": "https://cards.scryfall.io/large/front/0/0/00020b05-ecb9-4603-8cc1-8cfa7a14befc.jpg?1562633475",
+      "png": "https://cards.scryfall.io/png/front/0/0/00020b05-ecb9-4603-8cc1-8cfa7a14befc.png?1562633475",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00020b05-ecb9-4603-8cc1-8cfa7a14befc.jpg?1562633475",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00020b05-ecb9-4603-8cc1-8cfa7a14befc.jpg?1562633475"
+    },
+    "mana_cost": "{X}{G}{G}",
+    "cmc": 2,
+    "type_line": "Sorcery",
+    "oracle_text": "Manifest the top card of your library, then put X +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Manifest"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": true,
+    "reprint": true,
+    "variation": false,
+    "set_id": "fc7ea025-628e-45f4-9e0b-73681b1f68b7",
+    "set": "ugin",
+    "set_name": "Ugin's Fate",
+    "set_type": "promo",
+    "set_uri": "https://api.scryfall.com/sets/fc7ea025-628e-45f4-9e0b-73681b1f68b7",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Augin&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ugin?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00020b05-ecb9-4603-8cc1-8cfa7a14befc/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ad96ac790-428b-4a64-8dbd-6baa73eb6210&unique=prints",
+    "collector_number": "146",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "A howl on the wind hides many dangers.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Adam Paquette",
+    "artist_ids": [
+      "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
+    ],
+    "illustration_id": "b90c25fd-2ee1-4372-89d1-fc806d01d501",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "promo_types": [
+      "setpromo"
+    ],
+    "edhrec_rank": 18417,
+    "penny_rank": 11106,
+    "prices": {
+      "usd": "1.75",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "6.95",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=394089",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Wildcall&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Wildcall&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Wildcall"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/95585?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Wildcall&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Wildcall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0002ab72-834b-4c81-82b1-0d2760ea96b0",
+    "oracle_id": "645b5784-a6f7-4cf3-966a-e1a51420b96b",
+    "multiverse_ids": [
+      488632
+    ],
+    "mtgo_id": 81171,
+    "arena_id": 72048,
+    "tcgplayer_id": 215418,
+    "cardmarket_id": 467859,
+    "name": "Mystic Skyfish",
+    "lang": "en",
+    "released_at": "2020-07-03",
+    "uri": "https://api.scryfall.com/cards/0002ab72-834b-4c81-82b1-0d2760ea96b0",
+    "scryfall_uri": "https://scryfall.com/card/m21/326/mystic-skyfish?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1596250027",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1596250027",
+      "large": "https://cards.scryfall.io/large/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1596250027",
+      "png": "https://cards.scryfall.io/png/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.png?1596250027",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1596250027",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1596250027"
+    },
+    "mana_cost": "{2}{U}",
+    "cmc": 3,
+    "type_line": "Creature — Fish",
+    "oracle_text": "Whenever you draw your second card each turn, Mystic Skyfish gains flying until end of turn.",
+    "power": "3",
+    "toughness": "1",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "bc94aba1-7376-4e02-a12d-3a2efb66ab0f",
+    "set": "m21",
+    "set_name": "Core Set 2021",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/bc94aba1-7376-4e02-a12d-3a2efb66ab0f",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Am21&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/m21?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0002ab72-834b-4c81-82b1-0d2760ea96b0/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A645b5784-a6f7-4cf3-966a-e1a51420b96b&unique=prints",
+    "collector_number": "326",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "The problem wasn't that fish had learned how to fly. It was that sharks had adapted to follow them.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Alayna Danner",
+    "artist_ids": [
+      "bb677b1a-ce51-4888-83d6-5a94de461ff9"
+    ],
+    "illustration_id": "e553dd8e-e593-4504-82ed-cd7a6ad01a0a",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "promo_types": [
+      "planeswalkerdeck"
+    ],
+    "edhrec_rank": 22465,
+    "preview": {
+      "source": "CBR.com",
+      "source_uri": "https://www.cbr.com/magic-the-gathering-planeswalker-decks-core-set-2021/",
+      "previewed_at": "2020-06-05"
+    },
+    "prices": {
+      "usd": "0.12",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.08",
+      "eur_foil": null,
+      "tix": "0.19"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=488632",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mystic+Skyfish&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mystic+Skyfish&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mystic+Skyfish"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/215418?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mystic+Skyfish&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/81171?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00030770-5e99-4943-819d-8d807c24cc14",
+    "oracle_id": "56719f6a-1a6c-4c0a-8d21-18f7d7350b68",
+    "multiverse_ids": [
+      489643
+    ],
+    "arena_id": 72579,
+    "tcgplayer_id": 215984,
+    "cardmarket_id": 472559,
+    "name": "Swamp",
+    "lang": "en",
+    "released_at": "2020-07-17",
+    "uri": "https://api.scryfall.com/cards/00030770-5e99-4943-819d-8d807c24cc14",
+    "scryfall_uri": "https://scryfall.com/card/jmp/59/swamp?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1600716281",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1600716281",
+      "large": "https://cards.scryfall.io/large/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1600716281",
+      "png": "https://cards.scryfall.io/png/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.png?1600716281",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1600716281",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1600716281"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Swamp",
+    "oracle_text": "({T}: Add {B}.)",
+    "colors": [],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "B"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "arena",
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "0f6ccf25-a627-4263-86df-5757137f1696",
+    "set": "jmp",
+    "set_name": "Jumpstart",
+    "set_type": "draft_innovation",
+    "set_uri": "https://api.scryfall.com/sets/0f6ccf25-a627-4263-86df-5757137f1696",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ajmp&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/jmp?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00030770-5e99-4943-819d-8d807c24cc14/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A56719f6a-1a6c-4c0a-8d21-18f7d7350b68&unique=prints",
+    "collector_number": "59",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Adam Paquette",
+    "artist_ids": [
+      "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
+    ],
+    "illustration_id": "6b07ca0f-0cde-4798-b8f0-429f2fba450d",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "preview": {
+      "source": "GameStar",
+      "source_uri": "https://www.gamestar.de/galerien/magic_the_gathering_jumpstart,134800.html",
+      "previewed_at": "2020-06-17"
+    },
+    "prices": {
+      "usd": "0.22",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.59",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=489643",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Swamp&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Swamp&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Swamp"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/215984?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Swamp&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Swamp&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000366c8-7a43-49d7-a103-ac5bd7efd9aa",
+    "oracle_id": "56719f6a-1a6c-4c0a-8d21-18f7d7350b68",
+    "multiverse_ids": [
+      4925
+    ],
+    "mtgo_id": 9701,
+    "mtgo_foil_id": 9702,
+    "tcgplayer_id": 18500,
+    "cardmarket_id": 9070,
+    "name": "Swamp",
+    "lang": "en",
+    "released_at": "1997-10-14",
+    "uri": "https://api.scryfall.com/cards/000366c8-7a43-49d7-a103-ac5bd7efd9aa",
+    "scryfall_uri": "https://scryfall.com/card/tmp/340/swamp?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1562052318",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1562052318",
+      "large": "https://cards.scryfall.io/large/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1562052318",
+      "png": "https://cards.scryfall.io/png/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.png?1562052318",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1562052318",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1562052318"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Swamp",
+    "oracle_text": "({T}: Add {B}.)",
+    "colors": [],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "B"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "10df3a67-178e-4363-8668-34f0e6edf2a7",
+    "set": "tmp",
+    "set_name": "Tempest",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/10df3a67-178e-4363-8668-34f0e6edf2a7",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Atmp&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/tmp?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000366c8-7a43-49d7-a103-ac5bd7efd9aa/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A56719f6a-1a6c-4c0a-8d21-18f7d7350b68&unique=prints",
+    "collector_number": "340",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Brom",
+    "artist_ids": [
+      "bd79c951-2552-45dd-aae7-a333c2b7c1ef"
+    ],
+    "illustration_id": "bf15950f-cff4-442c-ab48-96f2042d49a2",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "0.40",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.30",
+      "eur_foil": null,
+      "tix": "0.04"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=4925",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Swamp&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Swamp&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Swamp"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/18500?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Swamp&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/9701?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000376ef-8b6c-490d-98cb-d6de15b2e585",
+    "oracle_id": "49f0b317-6b06-482e-ab64-e02713e6c7e8",
+    "multiverse_ids": [
+      574523
+    ],
+    "mtgo_id": 102562,
+    "arena_id": 82095,
+    "tcgplayer_id": 283405,
+    "cardmarket_id": 672314,
+    "name": "Battlewing Mystic",
+    "lang": "en",
+    "released_at": "2022-09-09",
+    "uri": "https://api.scryfall.com/cards/000376ef-8b6c-490d-98cb-d6de15b2e585",
+    "scryfall_uri": "https://scryfall.com/card/dmu/43/battlewing-mystic?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1673306662",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1673306662",
+      "large": "https://cards.scryfall.io/large/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1673306662",
+      "png": "https://cards.scryfall.io/png/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.png?1673306662",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1673306662",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1673306662"
+    },
+    "mana_cost": "{1}{U}",
+    "cmc": 2,
+    "type_line": "Creature — Bird Wizard",
+    "oracle_text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nFlying\nWhen Battlewing Mystic enters the battlefield, if it was kicked, discard your hand, then draw two cards.",
+    "power": "2",
+    "toughness": "1",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "R",
+      "U"
+    ],
+    "keywords": [
+      "Kicker",
+      "Flying"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "arena",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "4e47a6cd-cdeb-4b0f-8f24-cfe1a0127cb3",
+    "set": "dmu",
+    "set_name": "Dominaria United",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/4e47a6cd-cdeb-4b0f-8f24-cfe1a0127cb3",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Admu&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/dmu?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000376ef-8b6c-490d-98cb-d6de15b2e585/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A49f0b317-6b06-482e-ab64-e02713e6c7e8&unique=prints",
+    "collector_number": "43",
+    "digital": false,
+    "rarity": "uncommon",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Borja Pindado",
+    "artist_ids": [
+      "1624a1a8-3492-4c0b-9abc-83dcf2653111"
+    ],
+    "illustration_id": "6ca11e60-dfb4-466f-b7bf-ebef3cd7b0b0",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 19605,
+    "penny_rank": 7777,
+    "preview": {
+      "source": "Wizards of the Coast",
+      "source_uri": "https://weibo.com/n/万智牌MAGIC",
+      "previewed_at": "2022-08-23"
+    },
+    "prices": {
+      "usd": "0.03",
+      "usd_foil": "0.04",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.21",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=574523",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Battlewing+Mystic&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Battlewing+Mystic&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Battlewing+Mystic"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/283405?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Battlewing+Mystic&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/102562?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0003aa31-d42e-4972-9fb9-086aefe29a2c",
+    "oracle_id": "d3a0b660-358c-41bd-9cd2-41fbf3491b1a",
+    "multiverse_ids": [],
+    "tcgplayer_id": 242360,
+    "cardmarket_id": 581211,
+    "name": "Birds of Paradise",
+    "lang": "en",
+    "released_at": "2021-06-21",
+    "uri": "https://api.scryfall.com/cards/0003aa31-d42e-4972-9fb9-086aefe29a2c",
+    "scryfall_uri": "https://scryfall.com/card/sld/176/birds-of-paradise?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1675536851",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1675536851",
+      "large": "https://cards.scryfall.io/large/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1675536851",
+      "png": "https://cards.scryfall.io/png/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.png?1675536851",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1675536851",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1675536851"
+    },
+    "mana_cost": "{G}",
+    "cmc": 1,
+    "type_line": "Creature — Bird",
+    "oracle_text": "Flying\n{T}: Add one mana of any color.",
+    "power": "0",
+    "toughness": "1",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Flying"
+    ],
+    "produced_mana": [
+      "B",
+      "G",
+      "R",
+      "U",
+      "W"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "4d92a8a7-ccb0-437d-abdc-9d70fc5ed672",
+    "set": "sld",
+    "set_name": "Secret Lair Drop",
+    "set_type": "box",
+    "set_uri": "https://api.scryfall.com/sets/4d92a8a7-ccb0-437d-abdc-9d70fc5ed672",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Asld&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/sld?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0003aa31-d42e-4972-9fb9-086aefe29a2c/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ad3a0b660-358c-41bd-9cd2-41fbf3491b1a&unique=prints",
+    "collector_number": "176",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Mark Poole",
+    "artist_ids": [
+      "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
+    ],
+    "illustration_id": "96b78cb9-847b-428f-a887-e330c2d9f9ee",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 48,
+    "penny_rank": 44,
+    "prices": {
+      "usd": "6.73",
+      "usd_foil": "5.54",
+      "usd_etched": null,
+      "eur": "8.45",
+      "eur_foil": "8.99",
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Birds+of+Paradise&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Birds+of+Paradise&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Birds+of+Paradise"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/242360?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Birds+of+Paradise&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Birds+of+Paradise&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d",
+    "oracle_id": "a7887b24-977d-4a40-bb30-4bf467e5dba6",
+    "multiverse_ids": [
+      202610
+    ],
+    "mtgo_id": 38804,
+    "mtgo_foil_id": 38805,
+    "name": "Bronze Horse",
+    "lang": "en",
+    "released_at": "2011-01-10",
+    "uri": "https://api.scryfall.com/cards/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d",
+    "scryfall_uri": "https://scryfall.com/card/me4/186/bronze-horse?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d.jpg?1562894975",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d.jpg?1562894975",
+      "large": "https://cards.scryfall.io/large/front/0/0/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d.jpg?1562894975",
+      "png": "https://cards.scryfall.io/png/front/0/0/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d.png?1562894975",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d.jpg?1562894975",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d.jpg?1562894975"
+    },
+    "mana_cost": "{7}",
+    "cmc": 7,
+    "type_line": "Artifact Creature — Horse",
+    "oracle_text": "Trample\nAs long as you control another creature, prevent all damage that would be dealt to Bronze Horse by spells that target it.",
+    "power": "4",
+    "toughness": "4",
+    "colors": [],
+    "color_identity": [],
+    "keywords": [
+      "Trample"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "d38a13b7-6615-4c89-be7d-3b4eaacf1875",
+    "set": "me4",
+    "set_name": "Masters Edition IV",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/d38a13b7-6615-4c89-be7d-3b4eaacf1875",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ame4&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/me4?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0003b07e-0d6e-4844-93c7-3f1f6a7d8c4d/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aa7887b24-977d-4a40-bb30-4bf467e5dba6&unique=prints",
+    "collector_number": "186",
+    "digital": true,
+    "rarity": "uncommon",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Mark Poole",
+    "artist_ids": [
+      "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
+    ],
+    "illustration_id": "7e9fdcd2-8048-40a5-b1ae-bac89899182b",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 20355,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": "0.05"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=202610",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Bronze+Horse&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Bronze+Horse&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Bronze+Horse"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Bronze+Horse&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Bronze+Horse&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/38804?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00042443-4d4e-4087-b4e5-5e781e7cc5fa",
+    "oracle_id": "4fcfe370-ba33-438f-bd96-2ae560f59df9",
+    "multiverse_ids": [
+      24609
+    ],
+    "mtgo_id": 14297,
+    "mtgo_foil_id": 14298,
+    "tcgplayer_id": 7396,
+    "cardmarket_id": 3974,
+    "name": "Wall of Vipers",
+    "lang": "en",
+    "released_at": "2000-06-05",
+    "uri": "https://api.scryfall.com/cards/00042443-4d4e-4087-b4e5-5e781e7cc5fa",
+    "scryfall_uri": "https://scryfall.com/card/pcy/80/wall-of-vipers?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1562894988",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1562894988",
+      "large": "https://cards.scryfall.io/large/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1562894988",
+      "png": "https://cards.scryfall.io/png/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.png?1562894988",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1562894988",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1562894988"
+    },
+    "mana_cost": "{2}{B}",
+    "cmc": 3,
+    "type_line": "Creature — Snake Wall",
+    "oracle_text": "Defender (This creature can't attack.)\n{3}: Destroy Wall of Vipers and target creature it's blocking. Any player may activate this ability.",
+    "power": "2",
+    "toughness": "4",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [
+      "Defender"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "c233bd36-57c0-4aa2-ae6c-7aeabfb4e3ce",
+    "set": "pcy",
+    "set_name": "Prophecy",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/c233bd36-57c0-4aa2-ae6c-7aeabfb4e3ce",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Apcy&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/pcy?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00042443-4d4e-4087-b4e5-5e781e7cc5fa/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A4fcfe370-ba33-438f-bd96-2ae560f59df9&unique=prints",
+    "collector_number": "80",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "What wall can never be climbed, but is always scaled?\n—Nakaya riddle",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Marc Fishman",
+    "artist_ids": [
+      "d50dd2c3-34ae-4eb1-8948-cb4b38d7e4b9"
+    ],
+    "illustration_id": "65752f0f-a831-4575-a23c-daa54ac16c68",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 23505,
+    "prices": {
+      "usd": "0.22",
+      "usd_foil": "8.39",
+      "usd_etched": null,
+      "eur": "0.13",
+      "eur_foil": "2.20",
+      "tix": "0.09"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=24609",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Wall+of+Vipers&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Wall+of+Vipers&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Wall+of+Vipers"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/7396?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Wall+of+Vipers&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/14297?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0004311b-646a-4df8-a4b4-9171642e9ef4",
+    "oracle_id": "43b5e462-d860-473d-828f-6c513fc7768a",
+    "multiverse_ids": [],
+    "tcgplayer_id": 269127,
+    "cardmarket_id": 652296,
+    "name": "Admiral Beckett Brass",
+    "lang": "en",
+    "released_at": "2022-04-29",
+    "uri": "https://api.scryfall.com/cards/0004311b-646a-4df8-a4b4-9171642e9ef4",
+    "scryfall_uri": "https://scryfall.com/card/plist/735/admiral-beckett-brass?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0004311b-646a-4df8-a4b4-9171642e9ef4.jpg?1651796654",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0004311b-646a-4df8-a4b4-9171642e9ef4.jpg?1651796654",
+      "large": "https://cards.scryfall.io/large/front/0/0/0004311b-646a-4df8-a4b4-9171642e9ef4.jpg?1651796654",
+      "png": "https://cards.scryfall.io/png/front/0/0/0004311b-646a-4df8-a4b4-9171642e9ef4.png?1651796654",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0004311b-646a-4df8-a4b4-9171642e9ef4.jpg?1651796654",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0004311b-646a-4df8-a4b4-9171642e9ef4.jpg?1651796654"
+    },
+    "mana_cost": "{1}{U}{B}{R}",
+    "cmc": 4,
+    "type_line": "Legendary Creature — Human Pirate",
+    "oracle_text": "Other Pirates you control get +1/+1.\nAt the beginning of your end step, gain control of target nonland permanent controlled by a player who was dealt combat damage by three or more Pirates this turn.",
+    "power": "3",
+    "toughness": "3",
+    "colors": [
+      "B",
+      "R",
+      "U"
+    ],
+    "color_identity": [
+      "B",
+      "R",
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "67e47ba2-b019-4181-9005-fe9fc021de44",
+    "set": "plist",
+    "set_name": "The List",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/67e47ba2-b019-4181-9005-fe9fc021de44",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aplist&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/plist?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0004311b-646a-4df8-a4b4-9171642e9ef4/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A43b5e462-d860-473d-828f-6c513fc7768a&unique=prints",
+    "collector_number": "735",
+    "digital": false,
+    "rarity": "mythic",
+    "flavor_text": "\"You and your ship will make a fine addition to my fleet.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jason Rainville",
+    "artist_ids": [
+      "6ed7e669-579b-443d-b223-e5cbcb2a7483"
+    ],
+    "illustration_id": "8590b2be-8a63-4221-a043-d6b40fd2bc91",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 6347,
+    "penny_rank": 9860,
+    "prices": {
+      "usd": "0.88",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.85",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Admiral+Beckett+Brass&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Admiral+Beckett+Brass&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Admiral+Beckett+Brass"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/269127?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Admiral+Beckett+Brass&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Admiral+Beckett+Brass&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0005968a-8708-441b-b9a1-9373aeb8114d",
+    "oracle_id": "12c03a03-36bf-487e-b8be-e55399525da5",
+    "multiverse_ids": [
+      405311
+    ],
+    "tcgplayer_id": 107993,
+    "cardmarket_id": 285954,
+    "name": "Mulch",
+    "lang": "en",
+    "released_at": "2015-11-13",
+    "uri": "https://api.scryfall.com/cards/0005968a-8708-441b-b9a1-9373aeb8114d",
+    "scryfall_uri": "https://scryfall.com/card/c15/191/mulch?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0005968a-8708-441b-b9a1-9373aeb8114d.jpg?1562700539",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0005968a-8708-441b-b9a1-9373aeb8114d.jpg?1562700539",
+      "large": "https://cards.scryfall.io/large/front/0/0/0005968a-8708-441b-b9a1-9373aeb8114d.jpg?1562700539",
+      "png": "https://cards.scryfall.io/png/front/0/0/0005968a-8708-441b-b9a1-9373aeb8114d.png?1562700539",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0005968a-8708-441b-b9a1-9373aeb8114d.jpg?1562700539",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0005968a-8708-441b-b9a1-9373aeb8114d.jpg?1562700539"
+    },
+    "mana_cost": "{1}{G}",
+    "cmc": 2,
+    "type_line": "Sorcery",
+    "oracle_text": "Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "ea6c99f9-5489-4504-b30c-c819fa3b1fd3",
+    "set": "c15",
+    "set_name": "Commander 2015",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/ea6c99f9-5489-4504-b30c-c819fa3b1fd3",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ac15&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/c15?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0005968a-8708-441b-b9a1-9373aeb8114d/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A12c03a03-36bf-487e-b8be-e55399525da5&unique=prints",
+    "collector_number": "191",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "The land knows no difference between the graves of commoners and nobles.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Christopher Moeller",
+    "artist_ids": [
+      "21e10012-06ae-44f2-b38d-3824dd2e73d4"
+    ],
+    "illustration_id": "524f7ca7-7db4-48d5-94c8-5599bae09211",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 3993,
+    "penny_rank": 2519,
+    "prices": {
+      "usd": "0.06",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.17",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=405311",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mulch&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mulch&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mulch"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/107993?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mulch&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Mulch&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0005c844-787c-4f0c-8d25-85cec151642b",
+    "oracle_id": "53d5d961-d6a3-49b1-b335-2c2b49972008",
+    "multiverse_ids": [
+      450637
+    ],
+    "tcgplayer_id": 170970,
+    "cardmarket_id": 361746,
+    "name": "Whiptongue Hydra",
+    "lang": "en",
+    "released_at": "2018-08-09",
+    "uri": "https://api.scryfall.com/cards/0005c844-787c-4f0c-8d25-85cec151642b",
+    "scryfall_uri": "https://scryfall.com/card/c18/36/whiptongue-hydra?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0005c844-787c-4f0c-8d25-85cec151642b.jpg?1592710235",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0005c844-787c-4f0c-8d25-85cec151642b.jpg?1592710235",
+      "large": "https://cards.scryfall.io/large/front/0/0/0005c844-787c-4f0c-8d25-85cec151642b.jpg?1592710235",
+      "png": "https://cards.scryfall.io/png/front/0/0/0005c844-787c-4f0c-8d25-85cec151642b.png?1592710235",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0005c844-787c-4f0c-8d25-85cec151642b.jpg?1592710235",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0005c844-787c-4f0c-8d25-85cec151642b.jpg?1592710235"
+    },
+    "mana_cost": "{5}{G}",
+    "cmc": 6,
+    "type_line": "Creature — Lizard Hydra",
+    "oracle_text": "Reach\nWhen Whiptongue Hydra enters the battlefield, destroy all creatures with flying. Put a +1/+1 counter on Whiptongue Hydra for each creature destroyed this way.",
+    "power": "4",
+    "toughness": "4",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Reach"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "06ce6bc2-85cd-4cca-85b1-8c620d3e0902",
+    "set": "c18",
+    "set_name": "Commander 2018",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/06ce6bc2-85cd-4cca-85b1-8c620d3e0902",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ac18&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/c18?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0005c844-787c-4f0c-8d25-85cec151642b/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A53d5d961-d6a3-49b1-b335-2c2b49972008&unique=prints",
+    "collector_number": "36",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "\"Where'd all the birds go?\"\n—Kaldrin, jungle sightseer",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Tomasz Jedruszek",
+    "artist_ids": [
+      "bba69285-2445-4a4b-a847-59397be972ea"
+    ],
+    "illustration_id": "a5a61ad7-5d82-4a71-81f9-1500616ca2b6",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 4223,
+    "prices": {
+      "usd": "0.56",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "1.20",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=450637",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Whiptongue+Hydra&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Whiptongue+Hydra&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Whiptongue+Hydra"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/170970?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Whiptongue+Hydra&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Whiptongue+Hydra&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000619be-f2b4-407d-a76c-7245d8cab7bd",
+    "oracle_id": "3a21a6ae-b2f2-4f0c-acfd-5f3e8d63fd2f",
+    "multiverse_ids": [],
+    "tcgplayer_id": 38172,
+    "cardmarket_id": 19457,
+    "name": "Wall of Roots",
+    "lang": "en",
+    "released_at": "2008-01-01",
+    "uri": "https://api.scryfall.com/cards/000619be-f2b4-407d-a76c-7245d8cab7bd",
+    "scryfall_uri": "https://scryfall.com/card/f08/7/wall-of-roots?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000619be-f2b4-407d-a76c-7245d8cab7bd.jpg?1562164455",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000619be-f2b4-407d-a76c-7245d8cab7bd.jpg?1562164455",
+      "large": "https://cards.scryfall.io/large/front/0/0/000619be-f2b4-407d-a76c-7245d8cab7bd.jpg?1562164455",
+      "png": "https://cards.scryfall.io/png/front/0/0/000619be-f2b4-407d-a76c-7245d8cab7bd.png?1562164455",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000619be-f2b4-407d-a76c-7245d8cab7bd.jpg?1562164455",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000619be-f2b4-407d-a76c-7245d8cab7bd.jpg?1562164455"
+    },
+    "mana_cost": "{1}{G}",
+    "cmc": 2,
+    "type_line": "Creature — Plant Wall",
+    "oracle_text": "Defender\nPut a -0/-1 counter on Wall of Roots: Add {G}. Activate only once each turn.",
+    "power": "0",
+    "toughness": "5",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Defender"
+    ],
+    "produced_mana": [
+      "G"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": false,
+    "finishes": [
+      "foil"
+    ],
+    "oversized": false,
+    "promo": true,
+    "reprint": true,
+    "variation": false,
+    "set_id": "1d9c28af-5035-4b6d-9944-62b51cfd688d",
+    "set": "f08",
+    "set_name": "Friday Night Magic 2008",
+    "set_type": "promo",
+    "set_uri": "https://api.scryfall.com/sets/1d9c28af-5035-4b6d-9944-62b51cfd688d",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Af08&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/f08?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000619be-f2b4-407d-a76c-7245d8cab7bd/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A3a21a6ae-b2f2-4f0c-acfd-5f3e8d63fd2f&unique=prints",
+    "collector_number": "7",
+    "digital": false,
+    "rarity": "rare",
+    "watermark": "fnm",
+    "flavor_text": "Root systems in Mwonvuli twist through currents of mana rather than soil.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Matt Stewart",
+    "artist_ids": [
+      "20871267-2d8a-41d5-b03a-be3d557c5734"
+    ],
+    "illustration_id": "6d297367-b6e1-4b4f-a157-d7bb7d94a205",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "promo_types": [
+      "tourney",
+      "fnm"
+    ],
+    "edhrec_rank": 3145,
+    "prices": {
+      "usd": null,
+      "usd_foil": "5.05",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": "1.50",
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Wall+of+Roots&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Wall+of+Roots&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Wall+of+Roots"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/38172?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Wall+of+Roots&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Wall+of+Roots&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0007efdf-417d-48a7-b119-3a2fda3e1158",
+    "oracle_id": "2676d0c3-0a24-4e93-ae80-8f3fe03da483",
+    "multiverse_ids": [
+      607272
+    ],
+    "mtgo_id": 110316,
+    "arena_id": 84508,
+    "tcgplayer_id": 491326,
+    "cardmarket_id": 704403,
+    "name": "War Historian",
+    "lang": "en",
+    "released_at": "2023-04-21",
+    "uri": "https://api.scryfall.com/cards/0007efdf-417d-48a7-b119-3a2fda3e1158",
+    "scryfall_uri": "https://scryfall.com/card/mom/214/war-historian?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1682205143",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1682205143",
+      "large": "https://cards.scryfall.io/large/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1682205143",
+      "png": "https://cards.scryfall.io/png/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.png?1682205143",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1682205143",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1682205143"
+    },
+    "mana_cost": "{2}{G}",
+    "cmc": 3,
+    "type_line": "Creature — Human Monk",
+    "oracle_text": "Reach\nWar Historian has indestructible as long as it attacked a battle this turn.",
+    "power": "3",
+    "toughness": "3",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Reach"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "arena",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "392f7315-dc53-40a3-a2cc-5482dbd498b3",
+    "set": "mom",
+    "set_name": "March of the Machine",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/392f7315-dc53-40a3-a2cc-5482dbd498b3",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amom&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mom?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0007efdf-417d-48a7-b119-3a2fda3e1158/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A2676d0c3-0a24-4e93-ae80-8f3fe03da483&unique=prints",
+    "collector_number": "214",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "All children on Kamigawa learn of the Kami War. Hostilities with beings from another reality were understood, and no time was wasted in disbelief.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Ryan Valle",
+    "artist_ids": [
+      "6190569f-5e77-4bc1-bf22-9f85dba3a139"
+    ],
+    "illustration_id": "7df78cf7-a4a7-42f2-b2ab-fb768be7e2d7",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 23048,
+    "preview": {
+      "source": "Wizards of the Coast",
+      "source_uri": "https://www.twitch.tv/videos/1784560985",
+      "previewed_at": "2023-04-04"
+    },
+    "prices": {
+      "usd": "0.02",
+      "usd_foil": "0.02",
+      "usd_etched": null,
+      "eur": "0.06",
+      "eur_foil": "0.02",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=607272",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=War+Historian&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=War+Historian&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=War+Historian"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/491326?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=War+Historian&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/110316?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000809e6-2dd5-41cc-a316-3edb4e40eb58",
+    "oracle_id": "269fc857-a052-4f0a-9759-467ccf42bebb",
+    "multiverse_ids": [],
+    "tcgplayer_id": 97619,
+    "cardmarket_id": 17027,
+    "name": "Siren's Call",
+    "lang": "en",
+    "released_at": "1993-12-10",
+    "uri": "https://api.scryfall.com/cards/000809e6-2dd5-41cc-a316-3edb4e40eb58",
+    "scryfall_uri": "https://scryfall.com/card/ced/78/sirens-call?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000809e6-2dd5-41cc-a316-3edb4e40eb58.jpg?1559591503",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000809e6-2dd5-41cc-a316-3edb4e40eb58.jpg?1559591503",
+      "large": "https://cards.scryfall.io/large/front/0/0/000809e6-2dd5-41cc-a316-3edb4e40eb58.jpg?1559591503",
+      "png": "https://cards.scryfall.io/png/front/0/0/000809e6-2dd5-41cc-a316-3edb4e40eb58.png?1559591503",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000809e6-2dd5-41cc-a316-3edb4e40eb58.jpg?1559591503",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000809e6-2dd5-41cc-a316-3edb4e40eb58.jpg?1559591503"
+    },
+    "mana_cost": "{U}",
+    "cmc": 1,
+    "type_line": "Instant",
+    "oracle_text": "Cast this spell only during an opponent's turn, before attackers are declared.\nCreatures the active player controls attack this turn if able.\nAt the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn.",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "fdde66b9-027a-43e8-9aa4-5d338f379ade",
+    "set": "ced",
+    "set_name": "Collectors' Edition",
+    "set_type": "memorabilia",
+    "set_uri": "https://api.scryfall.com/sets/fdde66b9-027a-43e8-9aa4-5d338f379ade",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aced&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ced?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000809e6-2dd5-41cc-a316-3edb4e40eb58/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A269fc857-a052-4f0a-9759-467ccf42bebb&unique=prints",
+    "collector_number": "78",
+    "digital": false,
+    "rarity": "uncommon",
+    "card_back_id": "98784b63-d263-4abc-aabb-a092e6ecc788",
+    "artist": "Anson Maddocks",
+    "artist_ids": [
+      "634430a7-b5c3-4e4a-b2ac-164e084e47c9"
+    ],
+    "illustration_id": "c8812021-a07b-4279-83f6-0899849982e5",
+    "border_color": "black",
+    "frame": "1993",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 16308,
+    "prices": {
+      "usd": "3.10",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "2.48",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Siren%27s+Call&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Siren%27s+Call&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Siren%27s+Call"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/97619?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Siren%27s+Call&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Siren%27s+Call&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000a5154-90ba-459e-b122-d6893dfdb56f",
+    "oracle_id": "fb81f95c-70f8-4eb7-8d15-15d0ae23ec03",
+    "multiverse_ids": [
+      600972
+    ],
+    "mtgo_id": 108071,
+    "tcgplayer_id": 457259,
+    "name": "Mystical Tutor",
+    "lang": "en",
+    "released_at": "2023-01-13",
+    "uri": "https://api.scryfall.com/cards/000a5154-90ba-459e-b122-d6893dfdb56f",
+    "scryfall_uri": "https://scryfall.com/card/dmr/421/mystical-tutor?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1682714072",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1682714072",
+      "large": "https://cards.scryfall.io/large/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1682714072",
+      "png": "https://cards.scryfall.io/png/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.png?1682714072",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1682714072",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1682714072"
+    },
+    "mana_cost": "{U}",
+    "cmc": 1,
+    "type_line": "Instant",
+    "oracle_text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "banned",
+      "pauper": "not_legal",
+      "vintage": "restricted",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "banned",
+      "oldschool": "not_legal",
+      "premodern": "banned",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "ca4c2884-e539-4b7f-980d-5d6a50220f2a",
+    "set": "dmr",
+    "set_name": "Dominaria Remastered",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/ca4c2884-e539-4b7f-980d-5d6a50220f2a",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Admr&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/dmr?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000a5154-90ba-459e-b122-d6893dfdb56f/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Afb81f95c-70f8-4eb7-8d15-15d0ae23ec03&unique=prints",
+    "collector_number": "421",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "Wisdom is a well that never runs dry. It offers the most to those with the deepest thirst for knowledge.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Richard Kane Ferguson",
+    "artist_ids": [
+      "191620ed-2361-444e-96a6-1fe7ce32ef3b"
+    ],
+    "illustration_id": "0c7ff8ea-7ac8-431b-ae3a-5954ba31b74f",
+    "border_color": "borderless",
+    "frame": "2015",
+    "frame_effects": [
+      "inverted"
+    ],
+    "security_stamp": "oval",
+    "full_art": true,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "promo_types": [
+      "boosterfun"
+    ],
+    "edhrec_rank": 94,
+    "prices": {
+      "usd": "7.26",
+      "usd_foil": "9.52",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": "1.13"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=600972",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mystical+Tutor&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mystical+Tutor&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mystical+Tutor"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/457259?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mystical+Tutor&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/108071?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000a7263-37e6-4246-82f9-94459517a5cc",
+    "oracle_id": "6ca2a89e-7032-4864-b4e9-66f3178f90ab",
+    "multiverse_ids": [],
+    "mtgo_id": 95481,
+    "name": "Essence Warden",
+    "lang": "en",
+    "released_at": "2021-11-20",
+    "uri": "https://api.scryfall.com/cards/000a7263-37e6-4246-82f9-94459517a5cc",
+    "scryfall_uri": "https://scryfall.com/card/prm/95481/essence-warden?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000a7263-37e6-4246-82f9-94459517a5cc.jpg?1681087427",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000a7263-37e6-4246-82f9-94459517a5cc.jpg?1681087427",
+      "large": "https://cards.scryfall.io/large/front/0/0/000a7263-37e6-4246-82f9-94459517a5cc.jpg?1681087427",
+      "png": "https://cards.scryfall.io/png/front/0/0/000a7263-37e6-4246-82f9-94459517a5cc.png?1681087427",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000a7263-37e6-4246-82f9-94459517a5cc.jpg?1681087427",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000a7263-37e6-4246-82f9-94459517a5cc.jpg?1681087427"
+    },
+    "mana_cost": "{G}",
+    "cmc": 1,
+    "type_line": "Creature — Elf Shaman",
+    "oracle_text": "Whenever another creature enters the battlefield, you gain 1 life.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": true,
+    "reprint": true,
+    "variation": false,
+    "set_id": "638940fb-6be9-4be3-b83f-68d3902fbbe5",
+    "set": "prm",
+    "set_name": "Magic Online Promos",
+    "set_type": "promo",
+    "set_uri": "https://api.scryfall.com/sets/638940fb-6be9-4be3-b83f-68d3902fbbe5",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aprm&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/prm?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000a7263-37e6-4246-82f9-94459517a5cc/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A6ca2a89e-7032-4864-b4e9-66f3178f90ab&unique=prints",
+    "collector_number": "95481",
+    "digital": true,
+    "rarity": "rare",
+    "flavor_text": "\"Life begets life.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Goran Josic",
+    "artist_ids": [
+      "522bfda2-454a-4a74-b717-42930040f73a"
+    ],
+    "illustration_id": "095f3844-46e1-42ee-808a-d7471c99b564",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 1202,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": "0.22"
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Essence+Warden&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Essence+Warden&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Essence+Warden"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Essence+Warden&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Essence+Warden&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/95481?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000ac9e5-3c95-4e87-9424-109e2eea6b45",
+    "oracle_id": "ef75da10-1b33-4066-bd42-1111b5a94f75",
+    "multiverse_ids": [
+      452813
+    ],
+    "mtgo_id": 69499,
+    "arena_id": 68524,
+    "tcgplayer_id": 176680,
+    "cardmarket_id": 364124,
+    "name": "Blood Operative",
+    "lang": "en",
+    "released_at": "2018-10-05",
+    "uri": "https://api.scryfall.com/cards/000ac9e5-3c95-4e87-9424-109e2eea6b45",
+    "scryfall_uri": "https://scryfall.com/card/grn/63/blood-operative?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1572892902",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1572892902",
+      "large": "https://cards.scryfall.io/large/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1572892902",
+      "png": "https://cards.scryfall.io/png/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.png?1572892902",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1572892902",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1572892902"
+    },
+    "mana_cost": "{1}{B}{B}",
+    "cmc": 3,
+    "type_line": "Creature — Vampire Assassin",
+    "oracle_text": "Lifelink\nWhen Blood Operative enters the battlefield, you may exile target card from a graveyard.\nWhenever you surveil, if Blood Operative is in your graveyard, you may pay 3 life. If you do, return Blood Operative to your hand.",
+    "power": "3",
+    "toughness": "1",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [
+      "Lifelink"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "597c6d4a-8212-4903-a6af-12c4ae9e13f0",
+    "set": "grn",
+    "set_name": "Guilds of Ravnica",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/597c6d4a-8212-4903-a6af-12c4ae9e13f0",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Agrn&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/grn?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000ac9e5-3c95-4e87-9424-109e2eea6b45/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aef75da10-1b33-4066-bd42-1111b5a94f75&unique=prints",
+    "collector_number": "63",
+    "digital": false,
+    "rarity": "rare",
+    "watermark": "dimir",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Livia Prima",
+    "artist_ids": [
+      "0f41e561-bc26-4d85-aab6-66c384e01b74"
+    ],
+    "illustration_id": "a257fe8a-8cb2-4e64-9915-d11d066a1b46",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 14402,
+    "penny_rank": 7447,
+    "prices": {
+      "usd": "0.10",
+      "usd_foil": "0.34",
+      "usd_etched": null,
+      "eur": "0.26",
+      "eur_foil": "0.10",
+      "tix": "0.02"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=452813",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Blood+Operative&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Blood+Operative&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Blood+Operative"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/176680?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Blood+Operative&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/69499?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000ba9c3-cd88-47c1-966a-00466569a9bf",
+    "oracle_id": "8ee2dd43-cda2-4cb7-9e4b-1946d5b7467e",
+    "multiverse_ids": [
+      382359
+    ],
+    "tcgplayer_id": 83308,
+    "cardmarket_id": 267314,
+    "name": "Selvala's Enforcer",
+    "lang": "en",
+    "released_at": "2014-06-06",
+    "uri": "https://api.scryfall.com/cards/000ba9c3-cd88-47c1-966a-00466569a9bf",
+    "scryfall_uri": "https://scryfall.com/card/cns/40/selvalas-enforcer?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000ba9c3-cd88-47c1-966a-00466569a9bf.jpg?1562864254",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000ba9c3-cd88-47c1-966a-00466569a9bf.jpg?1562864254",
+      "large": "https://cards.scryfall.io/large/front/0/0/000ba9c3-cd88-47c1-966a-00466569a9bf.jpg?1562864254",
+      "png": "https://cards.scryfall.io/png/front/0/0/000ba9c3-cd88-47c1-966a-00466569a9bf.png?1562864254",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000ba9c3-cd88-47c1-966a-00466569a9bf.jpg?1562864254",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000ba9c3-cd88-47c1-966a-00466569a9bf.jpg?1562864254"
+    },
+    "mana_cost": "{3}{G}",
+    "cmc": 4,
+    "type_line": "Creature — Elf Warrior",
+    "oracle_text": "Parley — When Selvala's Enforcer enters the battlefield, each player reveals the top card of their library. For each nonland card revealed this way, put a +1/+1 counter on Selvala's Enforcer. Then each player draws a card.",
+    "power": "2",
+    "toughness": "2",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Parley"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "7d4ebb59-a50b-45b8-8fff-ab70767819a5",
+    "set": "cns",
+    "set_name": "Conspiracy",
+    "set_type": "draft_innovation",
+    "set_uri": "https://api.scryfall.com/sets/7d4ebb59-a50b-45b8-8fff-ab70767819a5",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Acns&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/cns?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000ba9c3-cd88-47c1-966a-00466569a9bf/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A8ee2dd43-cda2-4cb7-9e4b-1946d5b7467e&unique=prints",
+    "collector_number": "40",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jesper Ejsing",
+    "artist_ids": [
+      "a5f8354a-8b51-4e59-96b2-0e3aeae4fa1d"
+    ],
+    "illustration_id": "2d46eb5a-ccdf-4ba2-9742-dea608494348",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 17994,
+    "prices": {
+      "usd": "0.10",
+      "usd_foil": "0.69",
+      "usd_etched": null,
+      "eur": "0.20",
+      "eur_foil": "0.38",
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=382359",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Selvala%27s+Enforcer&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Selvala%27s+Enforcer&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Selvala%27s+Enforcer"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/83308?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Selvala%27s+Enforcer&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Selvala%27s+Enforcer&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000ce65b-5347-4a88-81af-be9053e4d3f3",
+    "oracle_id": "3be6e78f-f9ec-4bf4-b70f-40ba677aaa48",
+    "multiverse_ids": [
+      218051
+    ],
+    "mtgo_id": 39840,
+    "mtgo_foil_id": 39841,
+    "tcgplayer_id": 39415,
+    "cardmarket_id": 245935,
+    "name": "Fresh Meat",
+    "lang": "en",
+    "released_at": "2011-05-13",
+    "uri": "https://api.scryfall.com/cards/000ce65b-5347-4a88-81af-be9053e4d3f3",
+    "scryfall_uri": "https://scryfall.com/card/nph/109/fresh-meat?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1562875106",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1562875106",
+      "large": "https://cards.scryfall.io/large/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1562875106",
+      "png": "https://cards.scryfall.io/png/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.png?1562875106",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1562875106",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1562875106"
+    },
+    "mana_cost": "{3}{G}",
+    "cmc": 4,
+    "type_line": "Instant",
+    "oracle_text": "Create a 3/3 green Beast creature token for each creature put into your graveyard from the battlefield this turn.",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "000ce65b-5347-4a88-81af-be9053e4d3f3",
+        "component": "combo_piece",
+        "name": "Fresh Meat",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/000ce65b-5347-4a88-81af-be9053e4d3f3"
+      },
+      {
+        "object": "related_card",
+        "id": "7b226475-c85c-4b78-9d6a-70cc9545bc31",
+        "component": "token",
+        "name": "Beast",
+        "type_line": "Token Creature — Beast",
+        "uri": "https://api.scryfall.com/cards/7b226475-c85c-4b78-9d6a-70cc9545bc31"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "e8e356d8-6d01-4dab-aa07-d0999dc9359f",
+    "set": "nph",
+    "set_name": "New Phyrexia",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/e8e356d8-6d01-4dab-aa07-d0999dc9359f",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Anph&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/nph?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000ce65b-5347-4a88-81af-be9053e4d3f3/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A3be6e78f-f9ec-4bf4-b70f-40ba677aaa48&unique=prints",
+    "collector_number": "109",
+    "digital": false,
+    "rarity": "rare",
+    "watermark": "phyrexian",
+    "flavor_text": "A scavenger's favorite appetizer is death.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Dave Allsop",
+    "artist_ids": [
+      "99b8310a-4fd6-4ded-8ab7-3b5185821cbe"
+    ],
+    "illustration_id": "f1fabf9c-22a1-4d3a-9e91-dd41bed42f0b",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 5796,
+    "penny_rank": 5607,
+    "prices": {
+      "usd": "0.21",
+      "usd_foil": "1.13",
+      "usd_etched": null,
+      "eur": "0.35",
+      "eur_foil": "1.00",
+      "tix": "0.01"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=218051",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Fresh+Meat&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Fresh+Meat&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Fresh+Meat"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/39415?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Fresh+Meat&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/39840?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f",
+    "oracle_id": "57b37df5-fee4-4720-931f-f0cb0a8b338c",
+    "multiverse_ids": [
+      366374
+    ],
+    "mtgo_id": 47621,
+    "mtgo_foil_id": 47622,
+    "tcgplayer_id": 67327,
+    "cardmarket_id": 259832,
+    "name": "Orzhov Guildgate",
+    "lang": "en",
+    "released_at": "2013-02-01",
+    "uri": "https://api.scryfall.com/cards/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f",
+    "scryfall_uri": "https://scryfall.com/card/gtc/244/orzhov-guildgate?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1561813417",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1561813417",
+      "large": "https://cards.scryfall.io/large/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1561813417",
+      "png": "https://cards.scryfall.io/png/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.png?1561813417",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1561813417",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1561813417"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Land — Gate",
+    "oracle_text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
+    "colors": [],
+    "color_identity": [
+      "B",
+      "W"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "B",
+      "W"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "035a05f7-e020-4f50-a141-ed16ba704bd2",
+    "set": "gtc",
+    "set_name": "Gatecrash",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/035a05f7-e020-4f50-a141-ed16ba704bd2",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Agtc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/gtc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A57b37df5-fee4-4720-931f-f0cb0a8b338c&unique=prints",
+    "collector_number": "244",
+    "digital": false,
+    "rarity": "common",
+    "watermark": "orzhov",
+    "flavor_text": "Enter to find wealth, security, and eternal life . . . for just a small price up front.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "John Avon",
+    "artist_ids": [
+      "798f3932-30e0-4420-aa3f-db4d613f89ca"
+    ],
+    "illustration_id": "10ef67ba-9de0-4289-bb29-45432d581cbe",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 1263,
+    "penny_rank": 960,
+    "prices": {
+      "usd": "0.15",
+      "usd_foil": "2.39",
+      "usd_etched": null,
+      "eur": "0.08",
+      "eur_foil": "0.25",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=366374",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Orzhov+Guildgate&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Orzhov+Guildgate&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Orzhov+Guildgate"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/67327?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Orzhov+Guildgate&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/47621?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000d913b-adc4-4075-83d9-4a510280c91e",
+    "oracle_id": "faa01ed1-ccfa-4e58-951f-cd81f9068027",
+    "multiverse_ids": [
+      621379
+    ],
+    "mtgo_id": 112892,
+    "tcgplayer_id": 499547,
+    "cardmarket_id": 717370,
+    "name": "Mortify",
+    "lang": "en",
+    "released_at": "2023-06-23",
+    "uri": "https://api.scryfall.com/cards/000d913b-adc4-4075-83d9-4a510280c91e",
+    "scryfall_uri": "https://scryfall.com/card/ltc/269/mortify?utm_source=api",
+    "layout": "normal",
+    "highres_image": false,
+    "image_status": "lowres",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000d913b-adc4-4075-83d9-4a510280c91e.jpg?1686966266",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000d913b-adc4-4075-83d9-4a510280c91e.jpg?1686966266",
+      "large": "https://cards.scryfall.io/large/front/0/0/000d913b-adc4-4075-83d9-4a510280c91e.jpg?1686966266",
+      "png": "https://cards.scryfall.io/png/front/0/0/000d913b-adc4-4075-83d9-4a510280c91e.png?1686966266",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000d913b-adc4-4075-83d9-4a510280c91e.jpg?1686966266",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000d913b-adc4-4075-83d9-4a510280c91e.jpg?1686966266"
+    },
+    "mana_cost": "{1}{W}{B}",
+    "cmc": 3,
+    "type_line": "Instant",
+    "oracle_text": "Destroy target creature or enchantment.",
+    "colors": [
+      "B",
+      "W"
+    ],
+    "color_identity": [
+      "B",
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "e567c19c-0fe4-446e-a7bf-fce8a150cd2e",
+    "set": "ltc",
+    "set_name": "Tales of Middle-earth Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/e567c19c-0fe4-446e-a7bf-fce8a150cd2e",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Altc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ltc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000d913b-adc4-4075-83d9-4a510280c91e/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Afaa01ed1-ccfa-4e58-951f-cd81f9068027&unique=prints",
+    "collector_number": "269",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "Soon the rabbits were cut up and lying simmering in their pans with the bunched herbs.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Ilker Yildiz",
+    "artist_ids": [
+      "304b49a5-1469-469f-888f-870acea0883d"
+    ],
+    "illustration_id": "b3059631-f2cb-4ba0-8642-3698ea19a8cd",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "triangle",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 392,
+    "penny_rank": 2011,
+    "prices": {
+      "usd": "0.17",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.13",
+      "eur_foil": null,
+      "tix": "0.26"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=621379",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mortify&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mortify&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mortify"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/499547?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mortify&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/112892?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000db964-719d-4532-9225-35658565b35d",
+    "oracle_id": "ab26fbe2-e808-48b9-8d0d-3fbb6c3d554f",
+    "multiverse_ids": [],
+    "tcgplayer_id": 448641,
+    "name": "Narset, Parter of Veils",
+    "lang": "en",
+    "released_at": "2022-11-14",
+    "uri": "https://api.scryfall.com/cards/000db964-719d-4532-9225-35658565b35d",
+    "scryfall_uri": "https://scryfall.com/card/sld/1141/narset-parter-of-veils?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1666939107",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1666939107",
+      "large": "https://cards.scryfall.io/large/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1666939107",
+      "png": "https://cards.scryfall.io/png/front/0/0/000db964-719d-4532-9225-35658565b35d.png?1666939107",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1666939107",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1666939107"
+    },
+    "mana_cost": "{1}{U}{U}",
+    "cmc": 3,
+    "type_line": "Legendary Planeswalker — Narset",
+    "oracle_text": "Each opponent can't draw more than one card each turn.\n−2: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "loyalty": "5",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "restricted",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "4d92a8a7-ccb0-437d-abdc-9d70fc5ed672",
+    "set": "sld",
+    "set_name": "Secret Lair Drop",
+    "set_type": "box",
+    "set_uri": "https://api.scryfall.com/sets/4d92a8a7-ccb0-437d-abdc-9d70fc5ed672",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Asld&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/sld?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000db964-719d-4532-9225-35658565b35d/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aab26fbe2-e808-48b9-8d0d-3fbb6c3d554f&unique=prints",
+    "collector_number": "1141",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Uta Natsume",
+    "artist_ids": [
+      "03e3512f-03f5-4b26-97ff-ed5d9fb912c9"
+    ],
+    "illustration_id": "2a15aeb2-b827-4ae3-a70e-794a73637421",
+    "border_color": "borderless",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 329,
+    "preview": {
+      "source": "Wizards of the Coast",
+      "source_uri": "",
+      "previewed_at": "2022-10-01"
+    },
+    "prices": {
+      "usd": "19.21",
+      "usd_foil": "26.12",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Narset%2C+Parter+of+Veils&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Narset%2C+Parter+of+Veils&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Narset%2C+Parter+of+Veils"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/448641?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Narset%2C+Parter+of+Veils&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Narset%2C+Parter+of+Veils&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000e2f80-7667-4a8b-91c2-359121d44ebb",
+    "oracle_id": "e119869d-1f66-402b-8251-d351965cf0d3",
+    "multiverse_ids": [],
+    "tcgplayer_id": 513694,
+    "cardmarket_id": 730102,
+    "name": "Paradise Druid",
+    "lang": "en",
+    "released_at": "2023-09-08",
+    "uri": "https://api.scryfall.com/cards/000e2f80-7667-4a8b-91c2-359121d44ebb",
+    "scryfall_uri": "https://scryfall.com/card/woc/129/paradise-druid?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000e2f80-7667-4a8b-91c2-359121d44ebb.jpg?1692935557",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000e2f80-7667-4a8b-91c2-359121d44ebb.jpg?1692935557",
+      "large": "https://cards.scryfall.io/large/front/0/0/000e2f80-7667-4a8b-91c2-359121d44ebb.jpg?1692935557",
+      "png": "https://cards.scryfall.io/png/front/0/0/000e2f80-7667-4a8b-91c2-359121d44ebb.png?1692935557",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000e2f80-7667-4a8b-91c2-359121d44ebb.jpg?1692935557",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000e2f80-7667-4a8b-91c2-359121d44ebb.jpg?1692935557"
+    },
+    "mana_cost": "{1}{G}",
+    "cmc": 2,
+    "type_line": "Creature — Elf Druid",
+    "oracle_text": "Paradise Druid has hexproof as long as it's untapped. (It can't be the target of spells or abilities your opponents control.)\n{T}: Add one mana of any color.",
+    "power": "2",
+    "toughness": "1",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "B",
+      "G",
+      "R",
+      "U",
+      "W"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "51c0814a-2db2-4182-9aac-77340e9a540d",
+    "set": "woc",
+    "set_name": "Wilds of Eldraine Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/51c0814a-2db2-4182-9aac-77340e9a540d",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Awoc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/woc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000e2f80-7667-4a8b-91c2-359121d44ebb/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ae119869d-1f66-402b-8251-d351965cf0d3&unique=prints",
+    "collector_number": "129",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"There are many kinds of duty, and mine is to see our world grow and endure.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Nils Hamm",
+    "artist_ids": [
+      "c540d1fc-1500-457f-93cf-d6069ee66546"
+    ],
+    "illustration_id": "a2224f8a-646d-4537-9495-941bf22d8e19",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 1298,
+    "penny_rank": 713,
+    "prices": {
+      "usd": "0.16",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.19",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Paradise+Druid&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Paradise+Druid&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Paradise+Druid"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/513694?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Paradise+Druid&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Paradise+Druid&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000e88ab-f673-4822-bccb-a744f61060ef",
+    "oracle_id": "290faa28-450e-4797-9a8f-642d8af3f82a",
+    "multiverse_ids": [],
+    "tcgplayer_id": 513709,
+    "cardmarket_id": 730171,
+    "name": "Run Away Together",
+    "lang": "en",
+    "released_at": "2023-09-08",
+    "uri": "https://api.scryfall.com/cards/000e88ab-f673-4822-bccb-a744f61060ef",
+    "scryfall_uri": "https://scryfall.com/card/woc/108/run-away-together?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000e88ab-f673-4822-bccb-a744f61060ef.jpg?1692935235",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000e88ab-f673-4822-bccb-a744f61060ef.jpg?1692935235",
+      "large": "https://cards.scryfall.io/large/front/0/0/000e88ab-f673-4822-bccb-a744f61060ef.jpg?1692935235",
+      "png": "https://cards.scryfall.io/png/front/0/0/000e88ab-f673-4822-bccb-a744f61060ef.png?1692935235",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000e88ab-f673-4822-bccb-a744f61060ef.jpg?1692935235",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000e88ab-f673-4822-bccb-a744f61060ef.jpg?1692935235"
+    },
+    "mana_cost": "{1}{U}",
+    "cmc": 2,
+    "type_line": "Instant",
+    "oracle_text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "51c0814a-2db2-4182-9aac-77340e9a540d",
+    "set": "woc",
+    "set_name": "Wilds of Eldraine Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/51c0814a-2db2-4182-9aac-77340e9a540d",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Awoc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/woc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000e88ab-f673-4822-bccb-a744f61060ef/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A290faa28-450e-4797-9a8f-642d8af3f82a&unique=prints",
+    "collector_number": "108",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "True love means always knowing what's on the other's mind.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Filip Burburan",
+    "artist_ids": [
+      "66082c3b-a623-4d34-be51-2475214b85d3"
+    ],
+    "illustration_id": "145b1bef-a0cb-4f36-954d-ba1e455b64fd",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 3121,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.25",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Run+Away+Together&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Run+Away+Together&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Run+Away+Together"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/513709?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Run+Away+Together&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Run+Away+Together&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000edc61-b3ae-49e3-87f4-0250fa6a4501",
+    "oracle_id": "ffff90c3-63c4-4dee-a21d-6b2b113f4f80",
+    "multiverse_ids": [
+      509409
+    ],
+    "mtgo_id": 86451,
+    "tcgplayer_id": 233631,
+    "cardmarket_id": 542666,
+    "name": "Sinew Sliver",
+    "lang": "en",
+    "released_at": "2021-03-19",
+    "uri": "https://api.scryfall.com/cards/000edc61-b3ae-49e3-87f4-0250fa6a4501",
+    "scryfall_uri": "https://scryfall.com/card/tsr/44/sinew-sliver?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1619393551",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1619393551",
+      "large": "https://cards.scryfall.io/large/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1619393551",
+      "png": "https://cards.scryfall.io/png/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.png?1619393551",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1619393551",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1619393551"
+    },
+    "mana_cost": "{1}{W}",
+    "cmc": 2,
+    "type_line": "Creature — Sliver",
+    "oracle_text": "All Sliver creatures get +1/+1.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "11e90d1b-0502-43e6-b056-e24836523c13",
+    "set": "tsr",
+    "set_name": "Time Spiral Remastered",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/11e90d1b-0502-43e6-b056-e24836523c13",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Atsr&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/tsr?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000edc61-b3ae-49e3-87f4-0250fa6a4501/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Affff90c3-63c4-4dee-a21d-6b2b113f4f80&unique=prints",
+    "collector_number": "44",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "As the muscle cords of the creature twitched, Hanna saw an unsettling unanimity in the others' rippling flesh. She didn't know what it meant, but she urged Sisay to keep the ship at a safe distance.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Steven Belledin",
+    "artist_ids": [
+      "f07d73b9-52a0-4fe5-858b-61f7b42174a5"
+    ],
+    "illustration_id": "b8678fbe-de25-428d-88d9-dffe175eefbf",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 4252,
+    "penny_rank": 3035,
+    "preview": {
+      "source": "Wizards of the Coast",
+      "source_uri": "https://magic.wizards.com/en/articles/archive/card-image-gallery/time-spiral-remastered",
+      "previewed_at": "2021-02-26"
+    },
+    "prices": {
+      "usd": "0.26",
+      "usd_foil": "1.73",
+      "usd_etched": null,
+      "eur": "0.22",
+      "eur_foil": "1.49",
+      "tix": "0.04"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=509409",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Sinew+Sliver&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Sinew+Sliver&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Sinew+Sliver"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/233631?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Sinew+Sliver&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/86451?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000eded9-854c-408a-aadf-c26209e27432",
+    "oracle_id": "36b5022d-fa62-46ea-97ab-23c0f60f62a5",
+    "multiverse_ids": [
+      442898
+    ],
+    "mtgo_id": 67485,
+    "arena_id": 67124,
+    "tcgplayer_id": 162192,
+    "cardmarket_id": 319762,
+    "name": "Charge",
+    "lang": "en",
+    "released_at": "2018-04-27",
+    "uri": "https://api.scryfall.com/cards/000eded9-854c-408a-aadf-c26209e27432",
+    "scryfall_uri": "https://scryfall.com/card/dom/10/charge?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1562730460",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1562730460",
+      "large": "https://cards.scryfall.io/large/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1562730460",
+      "png": "https://cards.scryfall.io/png/front/0/0/000eded9-854c-408a-aadf-c26209e27432.png?1562730460",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1562730460",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1562730460"
+    },
+    "mana_cost": "{W}",
+    "cmc": 1,
+    "type_line": "Instant",
+    "oracle_text": "Creatures you control get +1/+1 until end of turn.",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "be1daba3-51c9-4e7e-9212-36e68addc26c",
+    "set": "dom",
+    "set_name": "Dominaria",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/be1daba3-51c9-4e7e-9212-36e68addc26c",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Adom&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/dom?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000eded9-854c-408a-aadf-c26209e27432/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A36b5022d-fa62-46ea-97ab-23c0f60f62a5&unique=prints",
+    "collector_number": "10",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"Honor rides before us. All we have to do is catch up.\"\n—Danitha Capashen",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Zezhou Chen",
+    "artist_ids": [
+      "810677e5-a502-4c03-b726-78cd808a75d4"
+    ],
+    "illustration_id": "4af18bc9-1e1e-4ff2-8459-9159849ef99b",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 15945,
+    "penny_rank": 4271,
+    "prices": {
+      "usd": "0.03",
+      "usd_foil": "0.11",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.02",
+      "tix": "0.04"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=442898",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Charge&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Charge&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Charge"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/162192?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Charge&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/67485?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "000f1f50-08e5-4d83-8159-98f06a0e2279",
+    "oracle_id": "b2c6aa39-2d2a-459c-a555-fb48ba993373",
+    "multiverse_ids": [
+      473217
+    ],
+    "mtgo_id": 78656,
+    "arena_id": 70402,
+    "tcgplayer_id": 199520,
+    "cardmarket_id": 402844,
+    "name": "Island",
+    "lang": "en",
+    "released_at": "2019-10-04",
+    "uri": "https://api.scryfall.com/cards/000f1f50-08e5-4d83-8159-98f06a0e2279",
+    "scryfall_uri": "https://scryfall.com/card/eld/255/island?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1572491305",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1572491305",
+      "large": "https://cards.scryfall.io/large/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1572491305",
+      "png": "https://cards.scryfall.io/png/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.png?1572491305",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1572491305",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1572491305"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Island",
+    "oracle_text": "({T}: Add {U}.)",
+    "colors": [],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "U"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "a90a7b2f-9dd8-4fc7-9f7d-8ea2797ec782",
+    "set": "eld",
+    "set_name": "Throne of Eldraine",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/a90a7b2f-9dd8-4fc7-9f7d-8ea2797ec782",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aeld&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/eld?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/000f1f50-08e5-4d83-8159-98f06a0e2279/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ab2c6aa39-2d2a-459c-a555-fb48ba993373&unique=prints",
+    "collector_number": "255",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Lucas Graciano",
+    "artist_ids": [
+      "ce98f39c-7cdd-47e6-a520-6c50443bb4c2"
+    ],
+    "illustration_id": "087b956b-9524-480f-bc3d-8f80e7af9fb6",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "0.08",
+      "usd_foil": "0.25",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.14",
+      "tix": "0.04"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=473217",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Island&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Island&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Island"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/199520?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Island&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/78656?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00101358-0e89-4bd1-b1f2-e889645b616e",
+    "oracle_id": "916d2a0d-1c3e-4102-958d-524b6b4df509",
+    "multiverse_ids": [
+      447166
+    ],
+    "mtgo_id": 68221,
+    "arena_id": 67740,
+    "tcgplayer_id": 169448,
+    "cardmarket_id": 360311,
+    "name": "Novice Knight",
+    "lang": "en",
+    "released_at": "2018-07-13",
+    "uri": "https://api.scryfall.com/cards/00101358-0e89-4bd1-b1f2-e889645b616e",
+    "scryfall_uri": "https://scryfall.com/card/m19/30/novice-knight?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1562300243",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1562300243",
+      "large": "https://cards.scryfall.io/large/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1562300243",
+      "png": "https://cards.scryfall.io/png/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.png?1562300243",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1562300243",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1562300243"
+    },
+    "mana_cost": "{W}",
+    "cmc": 1,
+    "type_line": "Creature — Human Knight",
+    "oracle_text": "Defender (This creature can't attack.)\nAs long as Novice Knight is enchanted or equipped, it can attack as though it didn't have defender.",
+    "power": "2",
+    "toughness": "3",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [
+      "Defender"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "2f5f2509-56db-414d-9a7e-6e312ec3760c",
+    "set": "m19",
+    "set_name": "Core Set 2019",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/2f5f2509-56db-414d-9a7e-6e312ec3760c",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Am19&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/m19?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00101358-0e89-4bd1-b1f2-e889645b616e/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A916d2a0d-1c3e-4102-958d-524b6b4df509&unique=prints",
+    "collector_number": "30",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "Even the greatest hero begins with nothing.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Yongjae Choi",
+    "artist_ids": [
+      "5ab91c3b-a6da-4751-a56e-81d0f61a67ab"
+    ],
+    "illustration_id": "15e82170-0d80-4759-9d1a-9fbc288e0bbf",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 15923,
+    "prices": {
+      "usd": "0.07",
+      "usd_foil": "0.41",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.45",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=447166",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Novice+Knight&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Novice+Knight&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Novice+Knight"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/169448?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Novice+Knight&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/68221?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00107210-313f-49c1-84ff-92628f75b764",
+    "oracle_id": "4956008e-d912-48ba-9b82-176258281060",
+    "multiverse_ids": [
+      3616
+    ],
+    "mtgo_id": 7545,
+    "mtgo_foil_id": 7546,
+    "tcgplayer_id": 5838,
+    "cardmarket_id": 8410,
+    "name": "Fallen Askari",
+    "lang": "en",
+    "released_at": "1997-02-03",
+    "uri": "https://api.scryfall.com/cards/00107210-313f-49c1-84ff-92628f75b764",
+    "scryfall_uri": "https://scryfall.com/card/vis/59/fallen-askari?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1562276948",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1562276948",
+      "large": "https://cards.scryfall.io/large/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1562276948",
+      "png": "https://cards.scryfall.io/png/front/0/0/00107210-313f-49c1-84ff-92628f75b764.png?1562276948",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1562276948",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1562276948"
+    },
+    "mana_cost": "{1}{B}",
+    "cmc": 2,
+    "type_line": "Creature — Human Knight",
+    "oracle_text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nFallen Askari can't block.",
+    "power": "2",
+    "toughness": "2",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [
+      "Flanking"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "2c32f1a9-7921-4826-bea0-80bbac70532c",
+    "set": "vis",
+    "set_name": "Visions",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/2c32f1a9-7921-4826-bea0-80bbac70532c",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Avis&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/vis?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00107210-313f-49c1-84ff-92628f75b764/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A4956008e-d912-48ba-9b82-176258281060&unique=prints",
+    "collector_number": "59",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "In troubled times, there are few greater sorrows than a wayward savior.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Adrian Smith",
+    "artist_ids": [
+      "be42f6f3-66d4-4957-9f1e-0591f8b95364"
+    ],
+    "illustration_id": "87ab7747-7c73-49ef-9077-ec6895d7983c",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 23770,
+    "penny_rank": 4141,
+    "prices": {
+      "usd": "0.16",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.05",
+      "eur_foil": null,
+      "tix": "0.09"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=3616",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Fallen+Askari&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Fallen+Askari&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Fallen+Askari"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/5838?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Fallen+Askari&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/7545?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00108a1c-e620-4124-9b31-3bb3ff2a0407",
+    "oracle_id": "6a125750-2b8c-4f9d-8173-ac8d14c91ddb",
+    "multiverse_ids": [],
+    "tcgplayer_id": 203585,
+    "cardmarket_id": 418161,
+    "name": "Altar's Reap",
+    "lang": "en",
+    "released_at": "2019-11-07",
+    "uri": "https://api.scryfall.com/cards/00108a1c-e620-4124-9b31-3bb3ff2a0407",
+    "scryfall_uri": "https://scryfall.com/card/mb1/563/altars-reap?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00108a1c-e620-4124-9b31-3bb3ff2a0407.jpg?1573508916",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00108a1c-e620-4124-9b31-3bb3ff2a0407.jpg?1573508916",
+      "large": "https://cards.scryfall.io/large/front/0/0/00108a1c-e620-4124-9b31-3bb3ff2a0407.jpg?1573508916",
+      "png": "https://cards.scryfall.io/png/front/0/0/00108a1c-e620-4124-9b31-3bb3ff2a0407.png?1573508916",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00108a1c-e620-4124-9b31-3bb3ff2a0407.jpg?1573508916",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00108a1c-e620-4124-9b31-3bb3ff2a0407.jpg?1573508916"
+    },
+    "mana_cost": "{1}{B}",
+    "cmc": 2,
+    "type_line": "Instant",
+    "oracle_text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "d13bfc70-6137-4179-aa96-da30fd84de29",
+    "set": "mb1",
+    "set_name": "Mystery Booster",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/d13bfc70-6137-4179-aa96-da30fd84de29",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amb1&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mb1?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00108a1c-e620-4124-9b31-3bb3ff2a0407/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A6a125750-2b8c-4f9d-8173-ac8d14c91ddb&unique=prints",
+    "collector_number": "563",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"I will secure my revenge on Zendikar one soul at a time.\"\n—Ob Nixilis",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Tyler Jacobson",
+    "artist_ids": [
+      "522af130-8db4-4b4b-950c-6e2b246339cf"
+    ],
+    "illustration_id": "fe25c91f-aaa2-43f5-a157-8caf118c9b70",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 2595,
+    "penny_rank": 5351,
+    "prices": {
+      "usd": "0.19",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.19",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Altar%27s+Reap&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Altar%27s+Reap&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Altar%27s+Reap"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/203585?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Altar%27s+Reap&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Altar%27s+Reap&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00111afb-26fe-487b-8d12-087cd8a8fe86",
+    "oracle_id": "ade898df-14a5-460b-94f6-1f3f74d3ff95",
+    "multiverse_ids": [
+      482724
+    ],
+    "tcgplayer_id": 212405,
+    "cardmarket_id": 453663,
+    "name": "Odric, Master Tactician",
+    "lang": "en",
+    "released_at": "2020-04-17",
+    "uri": "https://api.scryfall.com/cards/00111afb-26fe-487b-8d12-087cd8a8fe86",
+    "scryfall_uri": "https://scryfall.com/card/c20/96/odric-master-tactician?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00111afb-26fe-487b-8d12-087cd8a8fe86.jpg?1591320115",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00111afb-26fe-487b-8d12-087cd8a8fe86.jpg?1591320115",
+      "large": "https://cards.scryfall.io/large/front/0/0/00111afb-26fe-487b-8d12-087cd8a8fe86.jpg?1591320115",
+      "png": "https://cards.scryfall.io/png/front/0/0/00111afb-26fe-487b-8d12-087cd8a8fe86.png?1591320115",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00111afb-26fe-487b-8d12-087cd8a8fe86.jpg?1591320115",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00111afb-26fe-487b-8d12-087cd8a8fe86.jpg?1591320115"
+    },
+    "mana_cost": "{2}{W}{W}",
+    "cmc": 4,
+    "type_line": "Legendary Creature — Human Soldier",
+    "oracle_text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
+    "power": "3",
+    "toughness": "4",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [
+      "First strike"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "f60ec786-1f8d-42f7-9abc-0d880fe243f6",
+    "set": "c20",
+    "set_name": "Commander 2020",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/f60ec786-1f8d-42f7-9abc-0d880fe243f6",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ac20&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/c20?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00111afb-26fe-487b-8d12-087cd8a8fe86/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aade898df-14a5-460b-94f6-1f3f74d3ff95&unique=prints",
+    "collector_number": "96",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "\"Fear holds no place in faith's battle plan.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Michael Komarck",
+    "artist_ids": [
+      "96a53b95-fe5f-4fbb-9411-ccf4ee150aca"
+    ],
+    "illustration_id": "35818995-1935-4100-a36c-389c78f221b1",
+    "border_color": "black",
+    "frame": "2015",
+    "frame_effects": [
+      "legendary"
+    ],
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 1279,
+    "penny_rank": 4495,
+    "prices": {
+      "usd": "0.29",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.18",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=482724",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Odric%2C+Master+Tactician&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Odric%2C+Master+Tactician&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Odric%2C+Master+Tactician"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/212405?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Odric%2C+Master+Tactician&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Odric%2C+Master+Tactician&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0012621b-c0e1-48d6-99b9-ecca4763d748",
+    "oracle_id": "471f6ad3-cf01-42dd-a519-ea8e13039fea",
+    "multiverse_ids": [
+      29740
+    ],
+    "mtgo_id": 16777,
+    "mtgo_foil_id": 16778,
+    "tcgplayer_id": 9390,
+    "cardmarket_id": 2527,
+    "name": "Afflict",
+    "lang": "en",
+    "released_at": "2001-10-01",
+    "uri": "https://api.scryfall.com/cards/0012621b-c0e1-48d6-99b9-ecca4763d748",
+    "scryfall_uri": "https://scryfall.com/card/ody/115/afflict?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1562895004",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1562895004",
+      "large": "https://cards.scryfall.io/large/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1562895004",
+      "png": "https://cards.scryfall.io/png/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.png?1562895004",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1562895004",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1562895004"
+    },
+    "mana_cost": "{2}{B}",
+    "cmc": 3,
+    "type_line": "Instant",
+    "oracle_text": "Target creature gets -1/-1 until end of turn.\nDraw a card.",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "b0d90d2d-494a-4224-bfa0-36ce5ee281b1",
+    "set": "ody",
+    "set_name": "Odyssey",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/b0d90d2d-494a-4224-bfa0-36ce5ee281b1",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aody&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ody?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0012621b-c0e1-48d6-99b9-ecca4763d748/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A471f6ad3-cf01-42dd-a519-ea8e13039fea&unique=prints",
+    "collector_number": "115",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "When one of the Patriarch's champions displeased him, he would only shake his finger. That was enough.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Roger Raupp",
+    "artist_ids": [
+      "79d6f296-1948-4a24-a2ce-a76e89057f23"
+    ],
+    "illustration_id": "83259a38-bbad-4dd1-bcd5-d1b1d96b0380",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 17867,
+    "prices": {
+      "usd": "0.17",
+      "usd_foil": "0.28",
+      "usd_etched": null,
+      "eur": "0.11",
+      "eur_foil": "0.30",
+      "tix": "0.06"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=29740",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Afflict&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Afflict&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Afflict"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/9390?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Afflict&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/16777?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00127acd-a284-4bc8-bdfa-895914e3cd49",
+    "oracle_id": "f95021cf-14c4-4792-8746-432bf9e7c1a9",
+    "multiverse_ids": [
+      620761
+    ],
+    "mtgo_id": 113182,
+    "tcgplayer_id": 499765,
+    "cardmarket_id": 717412,
+    "name": "Crown of Gondor",
+    "lang": "en",
+    "released_at": "2023-06-23",
+    "uri": "https://api.scryfall.com/cards/00127acd-a284-4bc8-bdfa-895914e3cd49",
+    "scryfall_uri": "https://scryfall.com/card/ltc/75/crown-of-gondor?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00127acd-a284-4bc8-bdfa-895914e3cd49.jpg?1686964410",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00127acd-a284-4bc8-bdfa-895914e3cd49.jpg?1686964410",
+      "large": "https://cards.scryfall.io/large/front/0/0/00127acd-a284-4bc8-bdfa-895914e3cd49.jpg?1686964410",
+      "png": "https://cards.scryfall.io/png/front/0/0/00127acd-a284-4bc8-bdfa-895914e3cd49.png?1686964410",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00127acd-a284-4bc8-bdfa-895914e3cd49.jpg?1686964410",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00127acd-a284-4bc8-bdfa-895914e3cd49.jpg?1686964410"
+    },
+    "mana_cost": "{3}",
+    "cmc": 3,
+    "type_line": "Legendary Artifact — Equipment",
+    "oracle_text": "Equipped creature gets +1/+1 for each creature you control.\nWhen a legendary creature enters the battlefield under your control, if there is no monarch, you become the monarch.\nEquip {4}. This ability costs {3} less to activate if you're the monarch.",
+    "colors": [],
+    "color_identity": [],
+    "keywords": [
+      "Equip"
+    ],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "63455c28-3e53-45b1-8d0b-a5045dab1fb9",
+        "component": "combo_piece",
+        "name": "The Monarch",
+        "type_line": "Card",
+        "uri": "https://api.scryfall.com/cards/63455c28-3e53-45b1-8d0b-a5045dab1fb9"
+      },
+      {
+        "object": "related_card",
+        "id": "b29f1d8e-c305-4e8f-aa9e-a07985aea68c",
+        "component": "combo_piece",
+        "name": "Crown of Gondor",
+        "type_line": "Legendary Artifact — Equipment",
+        "uri": "https://api.scryfall.com/cards/b29f1d8e-c305-4e8f-aa9e-a07985aea68c"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "e567c19c-0fe4-446e-a7bf-fce8a150cd2e",
+    "set": "ltc",
+    "set_name": "Tales of Middle-earth Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/e567c19c-0fe4-446e-a7bf-fce8a150cd2e",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Altc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ltc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00127acd-a284-4bc8-bdfa-895914e3cd49/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Af95021cf-14c4-4792-8746-432bf9e7c1a9&unique=prints",
+    "collector_number": "75",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jarel Threat",
+    "artist_ids": [
+      "0fd89fbd-bd59-4ded-890e-731a8982f278"
+    ],
+    "illustration_id": "3e10ef18-e128-4d2d-bf63-a30b35fc6f7b",
+    "border_color": "black",
+    "frame": "2015",
+    "frame_effects": [
+      "legendary"
+    ],
+    "security_stamp": "triangle",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 8777,
+    "prices": {
+      "usd": "0.52",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.53",
+      "eur_foil": null,
+      "tix": "0.12"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=620761",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Crown+of+Gondor&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Crown+of+Gondor&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Crown+of+Gondor"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/499765?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Crown+of+Gondor&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/113182?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0013620d-8e17-4246-86bf-71eafd51b806",
+    "oracle_id": "1a137a67-4156-45c8-aae9-838f688e12bd",
+    "multiverse_ids": [
+      220041
+    ],
+    "mtgo_id": 42282,
+    "mtgo_foil_id": 42283,
+    "tcgplayer_id": 52194,
+    "cardmarket_id": 250440,
+    "name": "Invisible Stalker",
+    "lang": "en",
+    "released_at": "2011-09-30",
+    "uri": "https://api.scryfall.com/cards/0013620d-8e17-4246-86bf-71eafd51b806",
+    "scryfall_uri": "https://scryfall.com/card/isd/60/invisible-stalker?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1562825313",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1562825313",
+      "large": "https://cards.scryfall.io/large/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1562825313",
+      "png": "https://cards.scryfall.io/png/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.png?1562825313",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1562825313",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1562825313"
+    },
+    "mana_cost": "{1}{U}",
+    "cmc": 2,
+    "type_line": "Creature — Human Rogue",
+    "oracle_text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nInvisible Stalker can't be blocked.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [
+      "Hexproof"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "d1026945-2969-42b9-be53-f941405a58cb",
+    "set": "isd",
+    "set_name": "Innistrad",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/d1026945-2969-42b9-be53-f941405a58cb",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aisd&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/isd?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0013620d-8e17-4246-86bf-71eafd51b806/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A1a137a67-4156-45c8-aae9-838f688e12bd&unique=prints",
+    "collector_number": "60",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"All that concerns me is the vampires' sense of smell and those freezing Nephalian nights.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Bud Cook",
+    "artist_ids": [
+      "4c3be2d4-73e6-4005-b897-8ac65b9c8660"
+    ],
+    "illustration_id": "45ada61c-0e95-47db-b000-953c02470372",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 1518,
+    "penny_rank": 2210,
+    "prices": {
+      "usd": "0.45",
+      "usd_foil": "9.88",
+      "usd_etched": null,
+      "eur": "0.65",
+      "eur_foil": "5.00",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=220041",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Invisible+Stalker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Invisible+Stalker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Invisible+Stalker"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/52194?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Invisible+Stalker&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/42282?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0013a9c4-77a1-418d-85c2-bd68b65cd3d4",
+    "oracle_id": "335b5302-2272-405a-b2b8-3943b3df335f",
+    "multiverse_ids": [
+      522268
+    ],
+    "mtgo_id": 90761,
+    "tcgplayer_id": 239404,
+    "cardmarket_id": 565719,
+    "name": "Dakkon, Shadow Slayer",
+    "lang": "en",
+    "released_at": "2021-06-18",
+    "uri": "https://api.scryfall.com/cards/0013a9c4-77a1-418d-85c2-bd68b65cd3d4",
+    "scryfall_uri": "https://scryfall.com/card/mh2/192/dakkon-shadow-slayer?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1626098233",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1626098233",
+      "large": "https://cards.scryfall.io/large/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1626098233",
+      "png": "https://cards.scryfall.io/png/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.png?1626098233",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1626098233",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1626098233"
+    },
+    "mana_cost": "{W}{U}{B}",
+    "cmc": 3,
+    "type_line": "Legendary Planeswalker — Dakkon",
+    "oracle_text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n−3: Exile target creature.\n−6: You may put an artifact card from your hand or graveyard onto the battlefield.",
+    "loyalty": "0",
+    "colors": [
+      "B",
+      "U",
+      "W"
+    ],
+    "color_identity": [
+      "B",
+      "U",
+      "W"
+    ],
+    "keywords": [
+      "Surveil"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "c1c7eb8c-f205-40ab-a609-767cb296544e",
+    "set": "mh2",
+    "set_name": "Modern Horizons 2",
+    "set_type": "draft_innovation",
+    "set_uri": "https://api.scryfall.com/sets/c1c7eb8c-f205-40ab-a609-767cb296544e",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amh2&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mh2?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0013a9c4-77a1-418d-85c2-bd68b65cd3d4/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A335b5302-2272-405a-b2b8-3943b3df335f&unique=prints",
+    "collector_number": "192",
+    "digital": false,
+    "rarity": "mythic",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Richard Kane Ferguson",
+    "artist_ids": [
+      "191620ed-2361-444e-96a6-1fe7ce32ef3b"
+    ],
+    "illustration_id": "d4e99204-97a5-4f41-87c9-8bfa11b16a5c",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 4482,
+    "penny_rank": 1108,
+    "preview": {
+      "source": "Wizards of the Coast",
+      "source_uri": "https://www.twitch.tv/videos/1029499176",
+      "previewed_at": "2021-05-20"
+    },
+    "prices": {
+      "usd": "0.37",
+      "usd_foil": "3.15",
+      "usd_etched": null,
+      "eur": "0.61",
+      "eur_foil": "1.90",
+      "tix": "0.02"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=522268",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Dakkon%2C+Shadow+Slayer&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Dakkon%2C+Shadow+Slayer&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Dakkon%2C+Shadow+Slayer"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/239404?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Dakkon%2C+Shadow+Slayer&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/90761?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0014def3-4063-4929-ac51-76aef1bb2a68",
+    "oracle_id": "fc04f621-338b-4d4c-bf57-5e5a00d990f0",
+    "multiverse_ids": [
+      980
+    ],
+    "tcgplayer_id": 3240,
+    "cardmarket_id": 6846,
+    "name": "Shahrazad",
+    "lang": "en",
+    "released_at": "1993-12-17",
+    "uri": "https://api.scryfall.com/cards/0014def3-4063-4929-ac51-76aef1bb2a68",
+    "scryfall_uri": "https://scryfall.com/card/arn/10/shahrazad?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1562895012",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1562895012",
+      "large": "https://cards.scryfall.io/large/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1562895012",
+      "png": "https://cards.scryfall.io/png/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.png?1562895012",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1562895012",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1562895012"
+    },
+    "mana_cost": "{W}{W}",
+    "cmc": 2,
+    "type_line": "Sorcery",
+    "oracle_text": "Players play a Magic subgame, using their libraries as their decks. Each player who doesn't win the subgame loses half their life, rounded up.",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "banned",
+      "pauper": "not_legal",
+      "vintage": "banned",
+      "penny": "not_legal",
+      "commander": "banned",
+      "oathbreaker": "banned",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "banned",
+      "oldschool": "legal",
+      "premodern": "not_legal",
+      "predh": "banned"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": true,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "856f63eb-e056-43e5-8a56-7a58e1608940",
+    "set": "arn",
+    "set_name": "Arabian Nights",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/856f63eb-e056-43e5-8a56-7a58e1608940",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aarn&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/arn?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0014def3-4063-4929-ac51-76aef1bb2a68/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Afc04f621-338b-4d4c-bf57-5e5a00d990f0&unique=prints",
+    "collector_number": "10",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Kaja Foglio",
+    "artist_ids": [
+      "e8b85539-756a-4eac-ac66-a2258d7cf547"
+    ],
+    "illustration_id": "dcf24b76-d492-4539-883e-630c61113670",
+    "border_color": "black",
+    "frame": "1993",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "570.00",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "354.88",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=980",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Shahrazad&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Shahrazad&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Shahrazad"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/3240?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Shahrazad&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Shahrazad&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00154b70-57d2-4c32-860f-1c36fc49b10c",
+    "oracle_id": "e6ae536a-95c0-495d-98b8-200b3564dd79",
+    "multiverse_ids": [
+      423745
+    ],
+    "mtgo_id": 62727,
+    "mtgo_foil_id": 62728,
+    "tcgplayer_id": 126475,
+    "cardmarket_id": 294887,
+    "name": "Destructive Tampering",
+    "lang": "en",
+    "released_at": "2017-01-20",
+    "uri": "https://api.scryfall.com/cards/00154b70-57d2-4c32-860f-1c36fc49b10c",
+    "scryfall_uri": "https://scryfall.com/card/aer/78/destructive-tampering?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1576381772",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1576381772",
+      "large": "https://cards.scryfall.io/large/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1576381772",
+      "png": "https://cards.scryfall.io/png/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.png?1576381772",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1576381772",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1576381772"
+    },
+    "mana_cost": "{2}{R}",
+    "cmc": 3,
+    "type_line": "Sorcery",
+    "oracle_text": "Choose one —\n• Destroy target artifact.\n• Creatures without flying can't block this turn.",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "a4a0db50-8826-4e73-833c-3fd934375f96",
+    "set": "aer",
+    "set_name": "Aether Revolt",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/a4a0db50-8826-4e73-833c-3fd934375f96",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aaer&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/aer?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00154b70-57d2-4c32-860f-1c36fc49b10c/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ae6ae536a-95c0-495d-98b8-200b3564dd79&unique=prints",
+    "collector_number": "78",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"I don't think they'll appreciate my . . . adjustments.\"\n—Karavin, renegade saboteur",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Titus Lunter",
+    "artist_ids": [
+      "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
+    ],
+    "illustration_id": "03013a00-2171-4bb6-8a09-8226ff516535",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 13201,
+    "penny_rank": 11017,
+    "prices": {
+      "usd": "0.01",
+      "usd_foil": "0.21",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.14",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=423745",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Destructive+Tampering&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Destructive+Tampering&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Destructive+Tampering"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/126475?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Destructive+Tampering&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/62727?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0015d273-5f49-4154-9bd1-d3aef62d1c73",
+    "oracle_id": "0677f49e-f8bf-4349-af52-2ccde9287c2e",
+    "multiverse_ids": [],
+    "tcgplayer_id": 449460,
+    "name": "Mox Jet",
+    "lang": "en",
+    "released_at": "2022-11-28",
+    "uri": "https://api.scryfall.com/cards/0015d273-5f49-4154-9bd1-d3aef62d1c73",
+    "scryfall_uri": "https://scryfall.com/card/30a/556/mox-jet?utm_source=api",
+    "layout": "normal",
+    "highres_image": false,
+    "image_status": "lowres",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0015d273-5f49-4154-9bd1-d3aef62d1c73.jpg?1664929372",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0015d273-5f49-4154-9bd1-d3aef62d1c73.jpg?1664929372",
+      "large": "https://cards.scryfall.io/large/front/0/0/0015d273-5f49-4154-9bd1-d3aef62d1c73.jpg?1664929372",
+      "png": "https://cards.scryfall.io/png/front/0/0/0015d273-5f49-4154-9bd1-d3aef62d1c73.png?1664929372",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0015d273-5f49-4154-9bd1-d3aef62d1c73.jpg?1664929372",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0015d273-5f49-4154-9bd1-d3aef62d1c73.jpg?1664929372"
+    },
+    "mana_cost": "{0}",
+    "cmc": 0,
+    "type_line": "Artifact",
+    "oracle_text": "{T}: Add {B}.",
+    "colors": [],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "B"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "banned",
+      "pauper": "not_legal",
+      "vintage": "restricted",
+      "penny": "not_legal",
+      "commander": "banned",
+      "oathbreaker": "banned",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "banned",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "banned"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": true,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "c3cddb17-44d9-4abd-8d19-666f6c5171fe",
+    "set": "30a",
+    "set_name": "30th Anniversary Edition",
+    "set_type": "memorabilia",
+    "set_uri": "https://api.scryfall.com/sets/c3cddb17-44d9-4abd-8d19-666f6c5171fe",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A30a&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/30a?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0015d273-5f49-4154-9bd1-d3aef62d1c73/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A0677f49e-f8bf-4349-af52-2ccde9287c2e&unique=prints",
+    "collector_number": "556",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "049a6229-ace9-4363-816a-60cb8773e95d",
+    "artist": "Dan Frazier",
+    "artist_ids": [
+      "059bba56-5feb-42e4-8c2e-e2f1e6ba11f9"
+    ],
+    "illustration_id": "ae8c0bef-4639-4a12-8487-670919a1074b",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "1802.50",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mox+Jet&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mox+Jet&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mox+Jet"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/449460?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mox+Jet&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Mox+Jet&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0015ef55-4b85-4147-9974-b3ff4a1487c3",
+    "oracle_id": "7eff84f1-f772-497a-b350-bbc93d0230f7",
+    "multiverse_ids": [
+      482801
+    ],
+    "tcgplayer_id": 212510,
+    "cardmarket_id": 454018,
+    "name": "Harmonize",
+    "lang": "en",
+    "released_at": "2020-04-17",
+    "uri": "https://api.scryfall.com/cards/0015ef55-4b85-4147-9974-b3ff4a1487c3",
+    "scryfall_uri": "https://scryfall.com/card/c20/173/harmonize?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0015ef55-4b85-4147-9974-b3ff4a1487c3.jpg?1591320837",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0015ef55-4b85-4147-9974-b3ff4a1487c3.jpg?1591320837",
+      "large": "https://cards.scryfall.io/large/front/0/0/0015ef55-4b85-4147-9974-b3ff4a1487c3.jpg?1591320837",
+      "png": "https://cards.scryfall.io/png/front/0/0/0015ef55-4b85-4147-9974-b3ff4a1487c3.png?1591320837",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0015ef55-4b85-4147-9974-b3ff4a1487c3.jpg?1591320837",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0015ef55-4b85-4147-9974-b3ff4a1487c3.jpg?1591320837"
+    },
+    "mana_cost": "{2}{G}{G}",
+    "cmc": 4,
+    "type_line": "Sorcery",
+    "oracle_text": "Draw three cards.",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "f60ec786-1f8d-42f7-9abc-0d880fe243f6",
+    "set": "c20",
+    "set_name": "Commander 2020",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/f60ec786-1f8d-42f7-9abc-0d880fe243f6",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ac20&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/c20?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0015ef55-4b85-4147-9974-b3ff4a1487c3/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A7eff84f1-f772-497a-b350-bbc93d0230f7&unique=prints",
+    "collector_number": "173",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"Animals commune with their environment without the need for language. Theirs is a fundamental connection that surpasses flimsy words.\"\n—Vivien Reid",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Dan Scott",
+    "artist_ids": [
+      "f852fa13-137e-40f2-bbc1-0f01df09c0e0"
+    ],
+    "illustration_id": "4f780ecd-ff17-4d2b-a427-9d19fa3fa9b1",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 200,
+    "penny_rank": 815,
+    "prices": {
+      "usd": "0.37",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.22",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=482801",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Harmonize&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Harmonize&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Harmonize"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/212510?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Harmonize&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Harmonize&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0015fee8-068a-421e-9143-bcb575371f9a",
+    "oracle_id": "5b4b08a5-3af8-4c33-ab5e-7bee7f79e77a",
+    "multiverse_ids": [
+      3301
+    ],
+    "mtgo_id": 7171,
+    "mtgo_foil_id": 7172,
+    "tcgplayer_id": 5163,
+    "cardmarket_id": 8081,
+    "name": "Nocturnal Raid",
+    "lang": "en",
+    "released_at": "1996-10-08",
+    "uri": "https://api.scryfall.com/cards/0015fee8-068a-421e-9143-bcb575371f9a",
+    "scryfall_uri": "https://scryfall.com/card/mir/132/nocturnal-raid?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1562717466",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1562717466",
+      "large": "https://cards.scryfall.io/large/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1562717466",
+      "png": "https://cards.scryfall.io/png/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.png?1562717466",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1562717466",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1562717466"
+    },
+    "mana_cost": "{2}{B}{B}",
+    "cmc": 4,
+    "type_line": "Instant",
+    "oracle_text": "Black creatures get +2/+0 until end of turn.",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "5f06acf3-8123-4a78-b2e7-089b0b775a4a",
+    "set": "mir",
+    "set_name": "Mirage",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/5f06acf3-8123-4a78-b2e7-089b0b775a4a",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amir&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mir?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0015fee8-068a-421e-9143-bcb575371f9a/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A5b4b08a5-3af8-4c33-ab5e-7bee7f79e77a&unique=prints",
+    "collector_number": "132",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"The finest offering of night is not stealth but daring.\"\n—Tetlok, Breathstealer",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "John Matson",
+    "artist_ids": [
+      "a1685587-4b55-446b-b420-c37b202ed3f1"
+    ],
+    "illustration_id": "ce0740b0-58c8-4bd5-8c41-42534f655f2b",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 24400,
+    "penny_rank": 12645,
+    "prices": {
+      "usd": "0.18",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.15",
+      "eur_foil": null,
+      "tix": "0.09"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=3301",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Nocturnal+Raid&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Nocturnal+Raid&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Nocturnal+Raid"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/5163?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Nocturnal+Raid&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/7171?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0016ea50-4f77-4814-a505-8067ecb177cc",
+    "oracle_id": "6b6ac99a-7548-4cad-9fe5-ea611618ab9e",
+    "multiverse_ids": [],
+    "tcgplayer_id": 456565,
+    "name": "Temporal Manipulation",
+    "lang": "en",
+    "released_at": "2022-12-05",
+    "uri": "https://api.scryfall.com/cards/0016ea50-4f77-4814-a505-8067ecb177cc",
+    "scryfall_uri": "https://scryfall.com/card/sld/1169/temporal-manipulation?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1682694313",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1682694313",
+      "large": "https://cards.scryfall.io/large/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1682694313",
+      "png": "https://cards.scryfall.io/png/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.png?1682694313",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1682694313",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1682694313"
+    },
+    "mana_cost": "{3}{U}{U}",
+    "cmc": 5,
+    "type_line": "Sorcery",
+    "oracle_text": "Take an extra turn after this one.",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "banned",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "4d92a8a7-ccb0-437d-abdc-9d70fc5ed672",
+    "set": "sld",
+    "set_name": "Secret Lair Drop",
+    "set_type": "box",
+    "set_uri": "https://api.scryfall.com/sets/4d92a8a7-ccb0-437d-abdc-9d70fc5ed672",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Asld&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/sld?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0016ea50-4f77-4814-a505-8067ecb177cc/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A6b6ac99a-7548-4cad-9fe5-ea611618ab9e&unique=prints",
+    "collector_number": "1169",
+    "digital": false,
+    "rarity": "mythic",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Frank Frazetta",
+    "artist_ids": [
+      "2e5c787a-0a25-49a7-b51d-66e5795832ef"
+    ],
+    "illustration_id": "980407c7-feb2-415b-b2c8-90a49b875028",
+    "border_color": "borderless",
+    "frame": "2015",
+    "frame_effects": [
+      "inverted"
+    ],
+    "security_stamp": "oval",
+    "full_art": true,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 2621,
+    "prices": {
+      "usd": "17.53",
+      "usd_foil": "18.86",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Temporal+Manipulation&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Temporal+Manipulation&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Temporal+Manipulation"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/456565?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Temporal+Manipulation&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Temporal+Manipulation&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00174be7-0dc8-43b9-81b6-f25a8c3fb4eb",
+    "oracle_id": "180efbd4-0f77-41cc-8ae2-2e6ccf853d10",
+    "multiverse_ids": [],
+    "mtgo_id": 116290,
+    "arena_id": 86683,
+    "tcgplayer_id": 513013,
+    "cardmarket_id": 729036,
+    "name": "Archon of the Wild Rose",
+    "lang": "en",
+    "released_at": "2023-09-08",
+    "uri": "https://api.scryfall.com/cards/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb",
+    "scryfall_uri": "https://scryfall.com/card/woe/1/archon-of-the-wild-rose?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1692936281",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1692936281",
+      "large": "https://cards.scryfall.io/large/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1692936281",
+      "png": "https://cards.scryfall.io/png/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.png?1692936281",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1692936281",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1692936281"
+    },
+    "mana_cost": "{2}{W}{W}",
+    "cmc": 4,
+    "type_line": "Creature — Archon",
+    "oracle_text": "Flying\nOther creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.",
+    "power": "4",
+    "toughness": "4",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [
+      "Flying"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "arena",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "79139661-13ee-43c4-8bad-a8c069f1a1df",
+    "set": "woe",
+    "set_name": "Wilds of Eldraine",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/79139661-13ee-43c4-8bad-a8c069f1a1df",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Awoe&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/woe?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A180efbd4-0f77-41cc-8ae2-2e6ccf853d10&unique=prints",
+    "collector_number": "1",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "The curse of Redtooth Keep could only be broken by a mystical rose that blooms in moonlight.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Chris Rahn",
+    "artist_ids": [
+      "7742047e-0f80-4c0f-a530-d07460165e86"
+    ],
+    "illustration_id": "990dd0ce-f2d9-4321-855a-befc74e60478",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 21282,
+    "preview": {
+      "source": "Bandit",
+      "source_uri": "https://twitter.com/BanditMTG1/status/1692461342278471994",
+      "previewed_at": "2023-08-18"
+    },
+    "prices": {
+      "usd": "0.24",
+      "usd_foil": "0.33",
+      "usd_etched": null,
+      "eur": "0.37",
+      "eur_foil": "0.56",
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Archon+of+the+Wild+Rose&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Archon+of+the+Wild+Rose&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Archon+of+the+Wild+Rose"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/513013?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Archon+of+the+Wild+Rose&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/116290?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00177fcf-92af-475a-a7f5-11ab645388a5",
+    "oracle_id": "4d2cc2a8-e08a-420a-8922-c63e39129e23",
+    "multiverse_ids": [],
+    "name": "Vaevictis Asmadi",
+    "printed_name": "暴虐の覇王アスマディ",
+    "lang": "ja",
+    "released_at": "1995-07-01",
+    "uri": "https://api.scryfall.com/cards/00177fcf-92af-475a-a7f5-11ab645388a5",
+    "scryfall_uri": "https://scryfall.com/card/bchr/89/ja/%E6%9A%B4%E8%99%90%E3%81%AE%E8%A6%87%E7%8E%8B%E3%82%A2%E3%82%B9%E3%83%9E%E3%83%87%E3%82%A3?utm_source=api",
+    "layout": "normal",
+    "highres_image": false,
+    "image_status": "placeholder",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00177fcf-92af-475a-a7f5-11ab645388a5.jpg?1562894998",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00177fcf-92af-475a-a7f5-11ab645388a5.jpg?1562894998",
+      "large": "https://cards.scryfall.io/large/front/0/0/00177fcf-92af-475a-a7f5-11ab645388a5.jpg?1562894998",
+      "png": "https://cards.scryfall.io/png/front/0/0/00177fcf-92af-475a-a7f5-11ab645388a5.png?1562894998",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00177fcf-92af-475a-a7f5-11ab645388a5.jpg?1562894998",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00177fcf-92af-475a-a7f5-11ab645388a5.jpg?1562894998"
+    },
+    "mana_cost": "{2}{B}{B}{R}{R}{G}{G}",
+    "cmc": 8,
+    "type_line": "Legendary Creature — Elder Dragon",
+    "oracle_text": "Flying\nAt the beginning of your upkeep, sacrifice Vaevictis Asmadi unless you pay {B}{R}{G}.\n{B}: Vaevictis Asmadi gets +1/+0 until end of turn.\n{R}: Vaevictis Asmadi gets +1/+0 until end of turn.\n{G}: Vaevictis Asmadi gets +1/+0 until end of turn.",
+    "power": "7",
+    "toughness": "7",
+    "colors": [
+      "B",
+      "G",
+      "R"
+    ],
+    "color_identity": [
+      "B",
+      "G",
+      "R"
+    ],
+    "keywords": [
+      "Flying"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "d672ed60-4161-4b21-874a-584b13b2fc35",
+    "set": "bchr",
+    "set_name": "Chronicles Foreign Black Border",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/d672ed60-4161-4b21-874a-584b13b2fc35",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Abchr&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/bchr?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00177fcf-92af-475a-a7f5-11ab645388a5/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A4d2cc2a8-e08a-420a-8922-c63e39129e23&unique=prints",
+    "collector_number": "89",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Andi Rusu",
+    "artist_ids": [
+      "2fd69990-7ba4-4c0f-95ef-c7b748570a12"
+    ],
+    "illustration_id": "a770a481-3210-4b60-8308-5afcb3f17a22",
+    "border_color": "black",
+    "frame": "1993",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 16458,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Vaevictis+Asmadi&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Vaevictis+Asmadi&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Vaevictis+Asmadi"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Vaevictis+Asmadi&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Vaevictis+Asmadi&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Vaevictis+Asmadi&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0017de60-ee1c-4675-b04e-cdfa2c2a596e",
+    "oracle_id": "4b63bf36-cd0e-41d8-b0ca-aac459d91f3f",
+    "multiverse_ids": [
+      213817
+    ],
+    "mtgo_id": 39473,
+    "mtgo_foil_id": 39474,
+    "tcgplayer_id": 39061,
+    "cardmarket_id": 245334,
+    "name": "Flensermite",
+    "lang": "en",
+    "released_at": "2011-02-04",
+    "uri": "https://api.scryfall.com/cards/0017de60-ee1c-4675-b04e-cdfa2c2a596e",
+    "scryfall_uri": "https://scryfall.com/card/mbs/41/flensermite?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1562609238",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1562609238",
+      "large": "https://cards.scryfall.io/large/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1562609238",
+      "png": "https://cards.scryfall.io/png/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.png?1562609238",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1562609238",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1562609238"
+    },
+    "mana_cost": "{1}{B}",
+    "cmc": 2,
+    "type_line": "Creature — Phyrexian Gremlin",
+    "oracle_text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [
+      "Lifelink",
+      "Infect"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "f46c57e3-9301-4006-a6ca-06f3f65961fb",
+    "set": "mbs",
+    "set_name": "Mirrodin Besieged",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/f46c57e3-9301-4006-a6ca-06f3f65961fb",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ambs&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mbs?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0017de60-ee1c-4675-b04e-cdfa2c2a596e/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A4b63bf36-cd0e-41d8-b0ca-aac459d91f3f&unique=prints",
+    "collector_number": "41",
+    "digital": false,
+    "rarity": "common",
+    "watermark": "phyrexian",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Dave Allsop",
+    "artist_ids": [
+      "99b8310a-4fd6-4ded-8ab7-3b5185821cbe"
+    ],
+    "illustration_id": "e9f67865-8528-4dd6-adc4-037e8a55b2ab",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 7182,
+    "penny_rank": 3857,
+    "prices": {
+      "usd": "0.13",
+      "usd_foil": "2.72",
+      "usd_etched": null,
+      "eur": "0.24",
+      "eur_foil": "0.30",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=213817",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Flensermite&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Flensermite&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Flensermite"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/39061?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Flensermite&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/39473?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0017e784-5f71-4f7a-aed5-2ceff2cac18b",
+    "oracle_id": "74f67dcf-5afb-45aa-8d4b-3cdb23f6f2a1",
+    "multiverse_ids": [],
+    "tcgplayer_id": 210361,
+    "cardmarket_id": 443538,
+    "name": "Triskelion",
+    "lang": "en",
+    "released_at": "2020-03-08",
+    "uri": "https://api.scryfall.com/cards/0017e784-5f71-4f7a-aed5-2ceff2cac18b",
+    "scryfall_uri": "https://scryfall.com/card/fmb1/115/triskelion?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0017e784-5f71-4f7a-aed5-2ceff2cac18b.jpg?1583453177",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0017e784-5f71-4f7a-aed5-2ceff2cac18b.jpg?1583453177",
+      "large": "https://cards.scryfall.io/large/front/0/0/0017e784-5f71-4f7a-aed5-2ceff2cac18b.jpg?1583453177",
+      "png": "https://cards.scryfall.io/png/front/0/0/0017e784-5f71-4f7a-aed5-2ceff2cac18b.png?1583453177",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0017e784-5f71-4f7a-aed5-2ceff2cac18b.jpg?1583453177",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0017e784-5f71-4f7a-aed5-2ceff2cac18b.jpg?1583453177"
+    },
+    "mana_cost": "{6}",
+    "cmc": 6,
+    "type_line": "Artifact Creature — Construct",
+    "oracle_text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [],
+    "color_identity": [],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": false,
+    "finishes": [
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "b665b68c-61f6-4f0b-9d2f-8cc28a543be5",
+    "set": "fmb1",
+    "set_name": "Mystery Booster Retail Edition Foils",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/b665b68c-61f6-4f0b-9d2f-8cc28a543be5",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Afmb1&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/fmb1?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0017e784-5f71-4f7a-aed5-2ceff2cac18b/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A74f67dcf-5afb-45aa-8d4b-3cdb23f6f2a1&unique=prints",
+    "collector_number": "115",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "\"Why do bad things always come in threes?\"\n—Gisulf, expedition survivor",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Christopher Moeller",
+    "artist_ids": [
+      "21e10012-06ae-44f2-b38d-3824dd2e73d4"
+    ],
+    "illustration_id": "c69ca380-5d1f-47f7-a8e4-7ddd994fa503",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 2981,
+    "penny_rank": 958,
+    "prices": {
+      "usd": null,
+      "usd_foil": "0.47",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": "0.20",
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Triskelion&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Triskelion&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Triskelion"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/210361?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Triskelion&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Triskelion&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0018e4ea-8c46-4bb0-ade1-6b2a4f67c471",
+    "oracle_id": "984f92dd-cb9b-4421-a8e6-75bfe566be10",
+    "multiverse_ids": [
+      559846
+    ],
+    "tcgplayer_id": 269362,
+    "cardmarket_id": 652858,
+    "name": "Rite of the Raging Storm",
+    "lang": "en",
+    "released_at": "2022-04-29",
+    "uri": "https://api.scryfall.com/cards/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471",
+    "scryfall_uri": "https://scryfall.com/card/ncc/274/rite-of-the-raging-storm?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471.jpg?1673484403",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471.jpg?1673484403",
+      "large": "https://cards.scryfall.io/large/front/0/0/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471.jpg?1673484403",
+      "png": "https://cards.scryfall.io/png/front/0/0/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471.png?1673484403",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471.jpg?1673484403",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471.jpg?1673484403"
+    },
+    "mana_cost": "{3}{R}{R}",
+    "cmc": 5,
+    "type_line": "Enchantment",
+    "oracle_text": "Creatures named Lightning Rager can't attack you or planeswalkers you control.\nAt the beginning of each player's upkeep, that player creates a 5/1 red Elemental creature token named Lightning Rager. It has trample, haste, and \"At the beginning of the end step, sacrifice this creature.\"",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "32376be8-eb26-4129-9a4f-e37e0f428c6f",
+        "component": "token",
+        "name": "Lightning Rager",
+        "type_line": "Token Creature — Elemental",
+        "uri": "https://api.scryfall.com/cards/32376be8-eb26-4129-9a4f-e37e0f428c6f"
+      },
+      {
+        "object": "related_card",
+        "id": "0018e4ea-8c46-4bb0-ade1-6b2a4f67c471",
+        "component": "combo_piece",
+        "name": "Rite of the Raging Storm",
+        "type_line": "Enchantment",
+        "uri": "https://api.scryfall.com/cards/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "c51de34b-d4d6-4179-a432-573744ded119",
+    "set": "ncc",
+    "set_name": "New Capenna Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/c51de34b-d4d6-4179-a432-573744ded119",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ancc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ncc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0018e4ea-8c46-4bb0-ade1-6b2a4f67c471/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A984f92dd-cb9b-4421-a8e6-75bfe566be10&unique=prints",
+    "collector_number": "274",
+    "digital": false,
+    "rarity": "uncommon",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Svetlin Velinov",
+    "artist_ids": [
+      "ffd063ae-c097-4f26-b2e6-b1e2137708bc"
+    ],
+    "illustration_id": "958a771a-4318-44a9-a3c6-13afec306055",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 2800,
+    "prices": {
+      "usd": "0.42",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.38",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=559846",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Rite+of+the+Raging+Storm&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Rite+of+the+Raging+Storm&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Rite+of+the+Raging+Storm"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/269362?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Rite+of+the+Raging+Storm&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Rite+of+the+Raging+Storm&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "001c648a-db66-47f3-8fee-3658b9e76ac2",
+    "oracle_id": "195bd8fe-581c-44ed-b7f8-e800df3502ff",
+    "multiverse_ids": [
+      563159
+    ],
+    "mtgo_id": 100590,
+    "tcgplayer_id": 272634,
+    "cardmarket_id": 658492,
+    "name": "Gorion, Wise Mentor",
+    "lang": "en",
+    "released_at": "2022-06-10",
+    "uri": "https://api.scryfall.com/cards/001c648a-db66-47f3-8fee-3658b9e76ac2",
+    "scryfall_uri": "https://scryfall.com/card/clb/276/gorion-wise-mentor?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1674137521",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1674137521",
+      "large": "https://cards.scryfall.io/large/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1674137521",
+      "png": "https://cards.scryfall.io/png/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.png?1674137521",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1674137521",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1674137521"
+    },
+    "mana_cost": "{G}{W}{U}",
+    "cmc": 3,
+    "type_line": "Legendary Creature — Human Wizard",
+    "oracle_text": "Vigilance\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
+    "power": "3",
+    "toughness": "4",
+    "colors": [
+      "G",
+      "U",
+      "W"
+    ],
+    "color_identity": [
+      "G",
+      "U",
+      "W"
+    ],
+    "keywords": [
+      "Vigilance"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "5e4c3fe8-fd57-4b20-ad56-c03790a16cea",
+    "set": "clb",
+    "set_name": "Commander Legends: Battle for Baldur's Gate",
+    "set_type": "draft_innovation",
+    "set_uri": "https://api.scryfall.com/sets/5e4c3fe8-fd57-4b20-ad56-c03790a16cea",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aclb&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/clb?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/001c648a-db66-47f3-8fee-3658b9e76ac2/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A195bd8fe-581c-44ed-b7f8-e800df3502ff&unique=prints",
+    "collector_number": "276",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "\"You are safest in Candlekeep, Abdel, but I cannot keep you from the world forever.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jason Kang",
+    "artist_ids": [
+      "064b9176-e325-44f6-a413-2cadb7505851"
+    ],
+    "illustration_id": "81323bed-328e-4a78-ad4a-c0ef91e62951",
+    "border_color": "black",
+    "frame": "2015",
+    "frame_effects": [
+      "legendary"
+    ],
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 11372,
+    "preview": {
+      "source": "Wizards of the Coast",
+      "source_uri": "https://www.twitch.tv/videos/1486418408",
+      "previewed_at": "2022-05-17"
+    },
+    "prices": {
+      "usd": "0.12",
+      "usd_foil": "0.15",
+      "usd_etched": null,
+      "eur": "0.28",
+      "eur_foil": "0.23",
+      "tix": "0.12"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=563159",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Gorion%2C+Wise+Mentor&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Gorion%2C+Wise+Mentor&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Gorion%2C+Wise+Mentor"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/272634?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Gorion%2C+Wise+Mentor&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/100590?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "001cc57e-f3fc-4790-a9e5-171b2e3e8739",
+    "oracle_id": "04139d92-67d3-4e3c-a97f-158f24115044",
+    "multiverse_ids": [],
+    "name": "Wolf",
+    "lang": "en",
+    "released_at": "2021-11-19",
+    "uri": "https://api.scryfall.com/cards/001cc57e-f3fc-4790-a9e5-171b2e3e8739",
+    "scryfall_uri": "https://scryfall.com/card/tvow/11/wolf?utm_source=api",
+    "layout": "token",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1675457505",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1675457505",
+      "large": "https://cards.scryfall.io/large/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1675457505",
+      "png": "https://cards.scryfall.io/png/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.png?1675457505",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1675457505",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1675457505"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Token Creature — Wolf",
+    "oracle_text": "",
+    "power": "3",
+    "toughness": "2",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "001cc57e-f3fc-4790-a9e5-171b2e3e8739",
+        "component": "token",
+        "name": "Wolf",
+        "type_line": "Token Creature — Wolf",
+        "uri": "https://api.scryfall.com/cards/001cc57e-f3fc-4790-a9e5-171b2e3e8739"
+      },
+      {
+        "object": "related_card",
+        "id": "f76bddc3-f62e-4504-9703-8ed57acb90fa",
+        "component": "combo_piece",
+        "name": "Kessig Wolfrider",
+        "type_line": "Creature — Human Knight",
+        "uri": "https://api.scryfall.com/cards/f76bddc3-f62e-4504-9703-8ed57acb90fa"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "not_legal",
+      "pauper": "not_legal",
+      "vintage": "not_legal",
+      "penny": "not_legal",
+      "commander": "not_legal",
+      "oathbreaker": "not_legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "not_legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "381f2eb8-544e-409c-a8c5-7171cd78edea",
+    "set": "tvow",
+    "set_name": "Innistrad: Crimson Vow Tokens",
+    "set_type": "token",
+    "set_uri": "https://api.scryfall.com/sets/381f2eb8-544e-409c-a8c5-7171cd78edea",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Atvow&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/tvow?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/001cc57e-f3fc-4790-a9e5-171b2e3e8739/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A04139d92-67d3-4e3c-a97f-158f24115044&unique=prints",
+    "collector_number": "11",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Antonio José Manzanedo",
+    "artist_ids": [
+      "74986d28-0001-4a78-827c-e490b325d0e3"
+    ],
+    "illustration_id": "9295844c-5c01-4b5a-9bf3-5a9b68670165",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": true,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Wolf&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Wolf&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Wolf"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Wolf&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Wolf&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Wolf&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "001e8222-8dea-4767-8c13-21fb7ba556d7",
+    "oracle_id": "3425598f-d51c-4f92-8fda-42e96e4c537a",
+    "multiverse_ids": [
+      394579
+    ],
+    "mtgo_id": 56380,
+    "mtgo_foil_id": 56381,
+    "tcgplayer_id": 96695,
+    "cardmarket_id": 273409,
+    "name": "Gate Smasher",
+    "lang": "en",
+    "released_at": "2015-03-27",
+    "uri": "https://api.scryfall.com/cards/001e8222-8dea-4767-8c13-21fb7ba556d7",
+    "scryfall_uri": "https://scryfall.com/card/dtk/239/gate-smasher?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1562781756",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1562781756",
+      "large": "https://cards.scryfall.io/large/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1562781756",
+      "png": "https://cards.scryfall.io/png/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.png?1562781756",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1562781756",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1562781756"
+    },
+    "mana_cost": "{3}",
+    "cmc": 3,
+    "type_line": "Artifact — Equipment",
+    "oracle_text": "Gate Smasher can be attached only to a creature with toughness 4 or greater.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
+    "colors": [],
+    "color_identity": [],
+    "keywords": [
+      "Equip"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "7e72625f-f320-4552-a719-d11e2f1853bd",
+    "set": "dtk",
+    "set_name": "Dragons of Tarkir",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/7e72625f-f320-4552-a719-d11e2f1853bd",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Adtk&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/dtk?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/001e8222-8dea-4767-8c13-21fb7ba556d7/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A3425598f-d51c-4f92-8fda-42e96e4c537a&unique=prints",
+    "collector_number": "239",
+    "digital": false,
+    "rarity": "uncommon",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Filip Burburan",
+    "artist_ids": [
+      "66082c3b-a623-4d34-be51-2475214b85d3"
+    ],
+    "illustration_id": "49e85ed4-3ae0-4300-bb88-017a1df93755",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 18577,
+    "penny_rank": 13450,
+    "prices": {
+      "usd": "0.06",
+      "usd_foil": "0.20",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.12",
+      "tix": "0.05"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=394579",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Gate+Smasher&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Gate+Smasher&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Gate+Smasher"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/96695?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Gate+Smasher&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/56380?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "001eb913-2afe-4d7d-89a1-7c35de92d702",
+    "oracle_id": "b2c6aa39-2d2a-459c-a555-fb48ba993373",
+    "multiverse_ids": [],
+    "tcgplayer_id": 109684,
+    "name": "Island",
+    "printed_name": "Ile",
+    "lang": "fr",
+    "released_at": "1994-04-01",
+    "uri": "https://api.scryfall.com/cards/001eb913-2afe-4d7d-89a1-7c35de92d702",
+    "scryfall_uri": "https://scryfall.com/card/fbb/297/fr/ile?utm_source=api",
+    "layout": "normal",
+    "highres_image": false,
+    "image_status": "placeholder",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/001eb913-2afe-4d7d-89a1-7c35de92d702.jpg?1540162762",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/001eb913-2afe-4d7d-89a1-7c35de92d702.jpg?1540162762",
+      "large": "https://cards.scryfall.io/large/front/0/0/001eb913-2afe-4d7d-89a1-7c35de92d702.jpg?1540162762",
+      "png": "https://cards.scryfall.io/png/front/0/0/001eb913-2afe-4d7d-89a1-7c35de92d702.png?1540162762",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/001eb913-2afe-4d7d-89a1-7c35de92d702.jpg?1540162762",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/001eb913-2afe-4d7d-89a1-7c35de92d702.jpg?1540162762"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Island",
+    "oracle_text": "({T}: Add {U}.)",
+    "colors": [],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "U"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "60648044-9f6a-4961-81af-47a0a94dfac9",
+    "set": "fbb",
+    "set_name": "Foreign Black Border",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/60648044-9f6a-4961-81af-47a0a94dfac9",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Afbb&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/fbb?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/001eb913-2afe-4d7d-89a1-7c35de92d702/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ab2c6aa39-2d2a-459c-a555-fb48ba993373&unique=prints",
+    "collector_number": "297",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Mark Poole",
+    "artist_ids": [
+      "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
+    ],
+    "illustration_id": "0e4167bd-b5ab-452a-956d-885ef40e2354",
+    "border_color": "black",
+    "frame": "1993",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "3.79",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Island&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Island&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Island"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/109684?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Island&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Island&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "001f2658-9631-4ae8-a83b-3e922e243481",
+    "oracle_id": "cbf8d277-35b7-4047-b17e-677a73c874f2",
+    "multiverse_ids": [],
+    "name": "Kemba's Outfitter",
+    "lang": "en",
+    "released_at": "2023-02-28",
+    "uri": "https://api.scryfall.com/cards/001f2658-9631-4ae8-a83b-3e922e243481",
+    "scryfall_uri": "https://scryfall.com/card/yone/2/kembas-outfitter?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/001f2658-9631-4ae8-a83b-3e922e243481.jpg?1684523721",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/001f2658-9631-4ae8-a83b-3e922e243481.jpg?1684523721",
+      "large": "https://cards.scryfall.io/large/front/0/0/001f2658-9631-4ae8-a83b-3e922e243481.jpg?1684523721",
+      "png": "https://cards.scryfall.io/png/front/0/0/001f2658-9631-4ae8-a83b-3e922e243481.png?1684523721",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/001f2658-9631-4ae8-a83b-3e922e243481.jpg?1684523721",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/001f2658-9631-4ae8-a83b-3e922e243481.jpg?1684523721"
+    },
+    "mana_cost": "{W}",
+    "cmc": 1,
+    "type_line": "Creature — Cat Artificer",
+    "oracle_text": "When Kemba's Outfitter enters the battlefield, choose one —\n• Choose an Equipment card in your hand. It perpetually gains equip {1}.\n• Target Equipment you control perpetually gains equip {1}.",
+    "power": "2",
+    "toughness": "1",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "not_legal",
+      "pauper": "not_legal",
+      "vintage": "not_legal",
+      "penny": "not_legal",
+      "commander": "not_legal",
+      "oathbreaker": "not_legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "not_legal",
+      "duel": "not_legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "d34ef41f-624e-4bf2-9cec-7a7325e474c5",
+    "set": "yone",
+    "set_name": "Alchemy: Phyrexia",
+    "set_type": "alchemy",
+    "set_uri": "https://api.scryfall.com/sets/d34ef41f-624e-4bf2-9cec-7a7325e474c5",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ayone&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/yone?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/001f2658-9631-4ae8-a83b-3e922e243481/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Acbf8d277-35b7-4047-b17e-677a73c874f2&unique=prints",
+    "collector_number": "2",
+    "digital": true,
+    "rarity": "uncommon",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Samuel Perin",
+    "artist_ids": [
+      "1037066e-f63a-42dc-9850-9d14b6cfe436"
+    ],
+    "illustration_id": "e09d0580-a77e-456d-9e27-9ed3a6b106f9",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Kemba%27s+Outfitter&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Kemba%27s+Outfitter&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Kemba%27s+Outfitter"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0020a124-ba76-4d40-84e9-9803268d9f16",
+    "oracle_id": "deeb7e22-b207-42de-b9d4-f790403d52a9",
+    "multiverse_ids": [
+      407636
+    ],
+    "mtgo_id": 59563,
+    "mtgo_foil_id": 59564,
+    "tcgplayer_id": 110837,
+    "cardmarket_id": 287047,
+    "name": "World Breaker",
+    "lang": "en",
+    "released_at": "2016-01-22",
+    "uri": "https://api.scryfall.com/cards/0020a124-ba76-4d40-84e9-9803268d9f16",
+    "scryfall_uri": "https://scryfall.com/card/ogw/126/world-breaker?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014",
+      "large": "https://cards.scryfall.io/large/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014",
+      "png": "https://cards.scryfall.io/png/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.png?1562895014",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014"
+    },
+    "mana_cost": "{6}{G}",
+    "cmc": 7,
+    "type_line": "Creature — Eldrazi",
+    "oracle_text": "Devoid (This card has no color.)\nWhen you cast this spell, exile target artifact, enchantment, or land.\nReach\n{2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand. ({C} represents colorless mana.)",
+    "power": "5",
+    "toughness": "7",
+    "colors": [],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Reach",
+      "Devoid"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "cd51d245-8f95-45b0-ab5f-e2b3a3eb5dfe",
+    "set": "ogw",
+    "set_name": "Oath of the Gatewatch",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/cd51d245-8f95-45b0-ab5f-e2b3a3eb5dfe",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aogw&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ogw?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0020a124-ba76-4d40-84e9-9803268d9f16/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Adeeb7e22-b207-42de-b9d4-f790403d52a9&unique=prints",
+    "collector_number": "126",
+    "digital": false,
+    "rarity": "mythic",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jaime Jones",
+    "artist_ids": [
+      "92f6c2c1-fa57-4b52-99c4-0fd866c13dc9"
+    ],
+    "illustration_id": "92c9d95d-ea26-46c8-b473-1a3393b3a1c2",
+    "border_color": "black",
+    "frame": "2015",
+    "frame_effects": [
+      "devoid"
+    ],
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 5125,
+    "prices": {
+      "usd": "0.74",
+      "usd_foil": "5.01",
+      "usd_etched": null,
+      "eur": "1.90",
+      "eur_foil": "4.00",
+      "tix": "0.08"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=407636",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=World+Breaker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=World+Breaker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=World+Breaker"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/110837?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=World+Breaker&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/59563?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0020bf27-8160-4aaa-a321-29c8f43d2624",
+    "oracle_id": "17df95b2-49ef-43ca-b3c8-66a270f457a7",
+    "multiverse_ids": [],
+    "tcgplayer_id": 12793,
+    "name": "Rogue Kavu",
+    "lang": "en",
+    "released_at": "2005-07-29",
+    "uri": "https://api.scryfall.com/cards/0020bf27-8160-4aaa-a321-29c8f43d2624",
+    "scryfall_uri": "https://scryfall.com/card/9ed/213%E2%98%85/rogue-kavu?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1675829371",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1675829371",
+      "large": "https://cards.scryfall.io/large/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1675829371",
+      "png": "https://cards.scryfall.io/png/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.png?1675829371",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1675829371",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1675829371"
+    },
+    "mana_cost": "{1}{R}",
+    "cmc": 2,
+    "type_line": "Creature — Kavu",
+    "oracle_text": "Whenever Rogue Kavu attacks alone, it gets +2/+0 until end of turn.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": false,
+    "finishes": [
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "e70c8572-4732-4e92-a140-b4e3c1c84c93",
+    "set": "9ed",
+    "set_name": "Ninth Edition",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/e70c8572-4732-4e92-a140-b4e3c1c84c93",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A9ed&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/9ed?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0020bf27-8160-4aaa-a321-29c8f43d2624/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A17df95b2-49ef-43ca-b3c8-66a270f457a7&unique=prints",
+    "collector_number": "213★",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "Every litter of kavu yields one cub that refuses to hunt with the pack.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Darrell Riche",
+    "artist_ids": [
+      "262c8e55-4efc-467b-a042-6f734b9d2e01"
+    ],
+    "illustration_id": "aa6aa3e6-0d2c-49d8-92dd-1752a93520b2",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 23746,
+    "prices": {
+      "usd": null,
+      "usd_foil": "0.28",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Rogue+Kavu&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Rogue+Kavu&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Rogue+Kavu"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/12793?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Rogue+Kavu&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Rogue+Kavu&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00215182-51bd-4c7e-9675-179749a25a07",
+    "oracle_id": "b582b696-17fa-4eea-8124-293f9bd3a208",
+    "multiverse_ids": [
+      370496
+    ],
+    "mtgo_id": 48672,
+    "mtgo_foil_id": 48673,
+    "tcgplayer_id": 68356,
+    "cardmarket_id": 262050,
+    "name": "Mad Auntie",
+    "lang": "en",
+    "released_at": "2013-06-07",
+    "uri": "https://api.scryfall.com/cards/00215182-51bd-4c7e-9675-179749a25a07",
+    "scryfall_uri": "https://scryfall.com/card/mma/90/mad-auntie?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1561965987",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1561965987",
+      "large": "https://cards.scryfall.io/large/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1561965987",
+      "png": "https://cards.scryfall.io/png/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.png?1561965987",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1561965987",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1561965987"
+    },
+    "mana_cost": "{2}{B}",
+    "cmc": 3,
+    "type_line": "Creature — Goblin Shaman",
+    "oracle_text": "Other Goblin creatures you control get +1/+1.\n{T}: Regenerate another target Goblin.",
+    "power": "2",
+    "toughness": "2",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "0b7020f2-336d-4706-9ce6-f6710b9ebd5c",
+    "set": "mma",
+    "set_name": "Modern Masters",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/0b7020f2-336d-4706-9ce6-f6710b9ebd5c",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amma&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mma?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00215182-51bd-4c7e-9675-179749a25a07/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ab582b696-17fa-4eea-8124-293f9bd3a208&unique=prints",
+    "collector_number": "90",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "One part cunning, one part wise, and many, many parts demented.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Wayne Reynolds",
+    "artist_ids": [
+      "afc47cec-3ccc-404e-a8c6-4d83dd504271"
+    ],
+    "illustration_id": "3f52598a-c0b5-4355-baef-5d2ccfed13c5",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 7982,
+    "penny_rank": 3042,
+    "prices": {
+      "usd": "0.62",
+      "usd_foil": "0.89",
+      "usd_etched": null,
+      "eur": "0.74",
+      "eur_foil": "1.39",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=370496",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mad+Auntie&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mad+Auntie&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mad+Auntie"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/68356?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mad+Auntie&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/48672?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00223901-d462-41b0-9749-b093058f682f",
+    "oracle_id": "10706fd1-7847-4316-be8d-59b56143ce45",
+    "multiverse_ids": [
+      84073
+    ],
+    "mtgo_id": 22387,
+    "mtgo_foil_id": 22388,
+    "tcgplayer_id": 12607,
+    "cardmarket_id": 12311,
+    "name": "Coral Eel",
+    "lang": "en",
+    "released_at": "2005-07-29",
+    "uri": "https://api.scryfall.com/cards/00223901-d462-41b0-9749-b093058f682f",
+    "scryfall_uri": "https://scryfall.com/card/9ed/S3/coral-eel?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1562730475",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1562730475",
+      "large": "https://cards.scryfall.io/large/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1562730475",
+      "png": "https://cards.scryfall.io/png/front/0/0/00223901-d462-41b0-9749-b093058f682f.png?1562730475",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1562730475",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1562730475"
+    },
+    "mana_cost": "{1}{U}",
+    "cmc": 2,
+    "type_line": "Creature — Fish",
+    "oracle_text": "",
+    "power": "2",
+    "toughness": "1",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "e70c8572-4732-4e92-a140-b4e3c1c84c93",
+    "set": "9ed",
+    "set_name": "Ninth Edition",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/e70c8572-4732-4e92-a140-b4e3c1c84c93",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A9ed&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/9ed?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00223901-d462-41b0-9749-b093058f682f/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A10706fd1-7847-4316-be8d-59b56143ce45&unique=prints",
+    "collector_number": "S3",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "Some fishers like to eat eels, and some eels like to eat fishers.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Una Fricker",
+    "artist_ids": [
+      "0471a371-1bf8-49f2-8e76-cbe3a0bfa7e8"
+    ],
+    "illustration_id": "88017c4e-208c-414c-941d-575584ad73a4",
+    "border_color": "white",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "promo_types": [
+      "starterdeck"
+    ],
+    "edhrec_rank": 22796,
+    "prices": {
+      "usd": "0.15",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.08",
+      "eur_foil": null,
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=84073",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Coral+Eel&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Coral+Eel&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Coral+Eel"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/12607?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Coral+Eel&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/22387?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00255899-aaaf-46c6-8037-bd0e3c06250c",
+    "oracle_id": "7f8dad7f-a573-469f-9095-4ba3886b4f0b",
+    "multiverse_ids": [
+      607310,
+      607311
+    ],
+    "mtgo_id": 110392,
+    "arena_id": 84546,
+    "tcgplayer_id": 490498,
+    "cardmarket_id": 703462,
+    "name": "Invasion of Tolvada // The Broken Sky",
+    "lang": "en",
+    "released_at": "2023-04-21",
+    "uri": "https://api.scryfall.com/cards/00255899-aaaf-46c6-8037-bd0e3c06250c",
+    "scryfall_uri": "https://scryfall.com/card/mom/241/invasion-of-tolvada-the-broken-sky?utm_source=api",
+    "layout": "transform",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "cmc": 5,
+    "type_line": "Battle — Siege // Enchantment",
+    "color_identity": [
+      "B",
+      "W"
+    ],
+    "keywords": [
+      "Transform"
+    ],
+    "card_faces": [
+      {
+        "object": "card_face",
+        "name": "Invasion of Tolvada",
+        "mana_cost": "{3}{W}{B}",
+        "type_line": "Battle — Siege",
+        "oracle_text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Tolvada enters the battlefield, return target nonbattle permanent card from your graveyard to the battlefield.",
+        "colors": [
+          "B",
+          "W"
+        ],
+        "defense": "5",
+        "artist": "Henry Peters",
+        "artist_id": "2ffd9e06-94af-44f5-bec6-06f781941a6c",
+        "illustration_id": "e505aa78-b014-44aa-bee3-cb4f7dc587f0",
+        "image_uris": {
+          "small": "https://cards.scryfall.io/small/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "normal": "https://cards.scryfall.io/normal/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "large": "https://cards.scryfall.io/large/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "png": "https://cards.scryfall.io/png/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.png?1682715701",
+          "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701"
+        }
+      },
+      {
+        "object": "card_face",
+        "name": "The Broken Sky",
+        "flavor_name": "",
+        "mana_cost": "",
+        "type_line": "Enchantment",
+        "oracle_text": "Creature tokens you control get +1/+0 and have lifelink.\nAt the beginning of your end step, create a 1/1 white and black Spirit creature token with flying.",
+        "colors": [
+          "B",
+          "W"
+        ],
+        "color_indicator": [
+          "B",
+          "W"
+        ],
+        "flavor_text": "Angry ghosts poured through and pummeled the Invasion Tree, filling the heavens with the rhythms of war.",
+        "artist": "Henry Peters",
+        "artist_id": "2ffd9e06-94af-44f5-bec6-06f781941a6c",
+        "illustration_id": "e61d567e-03dc-4c8a-a773-65ae8cd7fdc9",
+        "image_uris": {
+          "small": "https://cards.scryfall.io/small/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "normal": "https://cards.scryfall.io/normal/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "large": "https://cards.scryfall.io/large/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "png": "https://cards.scryfall.io/png/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.png?1682715701",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1682715701"
+        }
+      }
+    ],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "b4311508-d045-4992-af44-703284de7e5a",
+        "component": "token",
+        "name": "Spirit",
+        "type_line": "Token Creature — Spirit",
+        "uri": "https://api.scryfall.com/cards/b4311508-d045-4992-af44-703284de7e5a"
+      },
+      {
+        "object": "related_card",
+        "id": "00255899-aaaf-46c6-8037-bd0e3c06250c",
+        "component": "combo_piece",
+        "name": "Invasion of Tolvada // The Broken Sky",
+        "type_line": "Battle — Siege // Enchantment",
+        "uri": "https://api.scryfall.com/cards/00255899-aaaf-46c6-8037-bd0e3c06250c"
+      }
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo",
+      "arena"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "392f7315-dc53-40a3-a2cc-5482dbd498b3",
+    "set": "mom",
+    "set_name": "March of the Machine",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/392f7315-dc53-40a3-a2cc-5482dbd498b3",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amom&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/mom?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00255899-aaaf-46c6-8037-bd0e3c06250c/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A7f8dad7f-a573-469f-9095-4ba3886b4f0b&unique=prints",
+    "collector_number": "241",
+    "digital": false,
+    "rarity": "rare",
+    "artist": "Henry Peters",
+    "artist_ids": [
+      "2ffd9e06-94af-44f5-bec6-06f781941a6c"
+    ],
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 9059,
+    "preview": {
+      "source": "Sean Plott (Day9TV)",
+      "source_uri": "https://twitter.com/day9tv/status/1641107950612934656",
+      "previewed_at": "2023-03-29"
+    },
+    "prices": {
+      "usd": "0.42",
+      "usd_foil": "0.50",
+      "usd_etched": null,
+      "eur": "0.43",
+      "eur_foil": "0.39",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=607310",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Invasion+of+Tolvada+%2F%2F+The+Broken+Sky&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Invasion+of+Tolvada+%2F%2F+The+Broken+Sky&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Invasion+of+Tolvada"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/490498?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Invasion+of+Tolvada&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/110392?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "002715a3-b84f-40ba-8fa9-6b2854626f4d",
+    "oracle_id": "8c17f48b-467e-4953-85d0-221cef5b3bff",
+    "multiverse_ids": [
+      6557
+    ],
+    "tcgplayer_id": 163,
+    "cardmarket_id": 9837,
+    "name": "Lurking Nightstalker",
+    "lang": "en",
+    "released_at": "1998-06-24",
+    "uri": "https://api.scryfall.com/cards/002715a3-b84f-40ba-8fa9-6b2854626f4d",
+    "scryfall_uri": "https://scryfall.com/card/p02/77/lurking-nightstalker?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1562895018",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1562895018",
+      "large": "https://cards.scryfall.io/large/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1562895018",
+      "png": "https://cards.scryfall.io/png/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.png?1562895018",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1562895018",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1562895018"
+    },
+    "mana_cost": "{B}{B}",
+    "cmc": 2,
+    "type_line": "Creature — Nightstalker",
+    "oracle_text": "Whenever Lurking Nightstalker attacks, it gets +2/+0 until end of turn.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "ac67f18a-4f0e-407e-bab1-a9fe4f659565",
+    "set": "p02",
+    "set_name": "Portal Second Age",
+    "set_type": "starter",
+    "set_uri": "https://api.scryfall.com/sets/ac67f18a-4f0e-407e-bab1-a9fe4f659565",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ap02&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/p02?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/002715a3-b84f-40ba-8fa9-6b2854626f4d/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A8c17f48b-467e-4953-85d0-221cef5b3bff&unique=prints",
+    "collector_number": "77",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "The shadows know.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Kev Walker",
+    "artist_ids": [
+      "f366a0ee-a0cd-466d-ba6a-90058c7a31a6"
+    ],
+    "illustration_id": "7dd4d2d0-1740-498c-8a89-2714675ccc94",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 24973,
+    "prices": {
+      "usd": "0.17",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.49",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=6557",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Lurking+Nightstalker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Lurking+Nightstalker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Lurking+Nightstalker"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/163?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Lurking+Nightstalker&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Lurking+Nightstalker&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0027e323-4f5a-412b-868d-6fb3a0c8050a",
+    "oracle_id": "c37f1921-7ac3-4185-8579-1dfdfe647ea2",
+    "multiverse_ids": [
+      383105
+    ],
+    "mtgo_id": 53035,
+    "mtgo_foil_id": 53036,
+    "name": "Spark Spray",
+    "lang": "en",
+    "released_at": "2014-06-16",
+    "uri": "https://api.scryfall.com/cards/0027e323-4f5a-412b-868d-6fb3a0c8050a",
+    "scryfall_uri": "https://scryfall.com/card/vma/188/spark-spray?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0027e323-4f5a-412b-868d-6fb3a0c8050a.jpg?1562895016",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0027e323-4f5a-412b-868d-6fb3a0c8050a.jpg?1562895016",
+      "large": "https://cards.scryfall.io/large/front/0/0/0027e323-4f5a-412b-868d-6fb3a0c8050a.jpg?1562895016",
+      "png": "https://cards.scryfall.io/png/front/0/0/0027e323-4f5a-412b-868d-6fb3a0c8050a.png?1562895016",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0027e323-4f5a-412b-868d-6fb3a0c8050a.jpg?1562895016",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0027e323-4f5a-412b-868d-6fb3a0c8050a.jpg?1562895016"
+    },
+    "mana_cost": "{R}",
+    "cmc": 1,
+    "type_line": "Instant",
+    "oracle_text": "Spark Spray deals 1 damage to any target.\nCycling {R} ({R}, Discard this card: Draw a card.)",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [
+      "Cycling"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "a944551a-73fa-41cd-9159-e8d0e4674403",
+    "set": "vma",
+    "set_name": "Vintage Masters",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/a944551a-73fa-41cd-9159-e8d0e4674403",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Avma&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/vma?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0027e323-4f5a-412b-868d-6fb3a0c8050a/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ac37f1921-7ac3-4185-8579-1dfdfe647ea2&unique=prints",
+    "collector_number": "188",
+    "digital": true,
+    "rarity": "common",
+    "flavor_text": "It's the only kind of shower goblins will tolerate.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Pete Venters",
+    "artist_ids": [
+      "d54c4a1a-c0c5-4834-84db-125d341f3ad8"
+    ],
+    "illustration_id": "3acb96b0-2827-4a70-95ce-a25fe4709b74",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 14731,
+    "penny_rank": 810,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": "0.04"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=383105",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Spark+Spray&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Spark+Spray&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Spark+Spray"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Spark+Spray&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Spark+Spray&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/53035?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0027e5ca-8046-40a0-bd73-79be55f28bff",
+    "oracle_id": "d71cd08e-3e84-41ff-b9db-9e343c0af6b4",
+    "multiverse_ids": [
+      380255
+    ],
+    "mtgo_id": 52505,
+    "mtgo_foil_id": 52506,
+    "tcgplayer_id": 79991,
+    "cardmarket_id": 266383,
+    "name": "Remand",
+    "lang": "en",
+    "released_at": "2014-03-14",
+    "uri": "https://api.scryfall.com/cards/0027e5ca-8046-40a0-bd73-79be55f28bff",
+    "scryfall_uri": "https://scryfall.com/card/ddm/26/remand?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0027e5ca-8046-40a0-bd73-79be55f28bff.jpg?1592754515",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0027e5ca-8046-40a0-bd73-79be55f28bff.jpg?1592754515",
+      "large": "https://cards.scryfall.io/large/front/0/0/0027e5ca-8046-40a0-bd73-79be55f28bff.jpg?1592754515",
+      "png": "https://cards.scryfall.io/png/front/0/0/0027e5ca-8046-40a0-bd73-79be55f28bff.png?1592754515",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0027e5ca-8046-40a0-bd73-79be55f28bff.jpg?1592754515",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0027e5ca-8046-40a0-bd73-79be55f28bff.jpg?1592754515"
+    },
+    "mana_cost": "{1}{U}",
+    "cmc": 2,
+    "type_line": "Instant",
+    "oracle_text": "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "a80b4ba1-7485-4c16-b745-eeea904863c3",
+    "set": "ddm",
+    "set_name": "Duel Decks: Jace vs. Vraska",
+    "set_type": "duel_deck",
+    "set_uri": "https://api.scryfall.com/sets/a80b4ba1-7485-4c16-b745-eeea904863c3",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Addm&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ddm?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0027e5ca-8046-40a0-bd73-79be55f28bff/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ad71cd08e-3e84-41ff-b9db-9e343c0af6b4&unique=prints",
+    "collector_number": "26",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "For the Azorius, the law can be a physical shield against chaos and anarchy.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Zoltan Boros",
+    "artist_ids": [
+      "1885e6cb-c827-4896-994e-3d0a027d602f"
+    ],
+    "illustration_id": "85795d09-a7f2-4c9a-9e85-e1ec07ffb5e8",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 3980,
+    "prices": {
+      "usd": "1.23",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "1.95",
+      "eur_foil": null,
+      "tix": "1.37"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=380255",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Remand&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Remand&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Remand"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/79991?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Remand&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/52505?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00293ce4-3475-4064-8510-9e8c02faf3bf",
+    "oracle_id": "bc71ebf6-2056-41f7-be35-b2e5c34afa99",
+    "multiverse_ids": [
+      430511
+    ],
+    "tcgplayer_id": 131941,
+    "cardmarket_id": 298240,
+    "name": "Plains",
+    "lang": "en",
+    "released_at": "2017-06-09",
+    "uri": "https://api.scryfall.com/cards/00293ce4-3475-4064-8510-9e8c02faf3bf",
+    "scryfall_uri": "https://scryfall.com/card/cma/292/plains?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00293ce4-3475-4064-8510-9e8c02faf3bf.jpg?1592674050",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00293ce4-3475-4064-8510-9e8c02faf3bf.jpg?1592674050",
+      "large": "https://cards.scryfall.io/large/front/0/0/00293ce4-3475-4064-8510-9e8c02faf3bf.jpg?1592674050",
+      "png": "https://cards.scryfall.io/png/front/0/0/00293ce4-3475-4064-8510-9e8c02faf3bf.png?1592674050",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00293ce4-3475-4064-8510-9e8c02faf3bf.jpg?1592674050",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00293ce4-3475-4064-8510-9e8c02faf3bf.jpg?1592674050"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Plains",
+    "oracle_text": "({T}: Add {W}.)",
+    "colors": [],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "W"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "fd4d8463-0156-4c60-a40e-778762bb90e4",
+    "set": "cma",
+    "set_name": "Commander Anthology",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/fd4d8463-0156-4c60-a40e-778762bb90e4",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Acma&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/cma?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00293ce4-3475-4064-8510-9e8c02faf3bf/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Abc71ebf6-2056-41f7-be35-b2e5c34afa99&unique=prints",
+    "collector_number": "292",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Andreas Rocha",
+    "artist_ids": [
+      "d084e74b-f63a-4107-b72c-ed6250ecc93b"
+    ],
+    "illustration_id": "6fa3ffd2-e3b6-4ab6-a004-4c43cb94fc13",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "0.10",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.09",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=430511",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Plains&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Plains&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Plains"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/131941?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Plains&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Plains&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00298672-079c-4c92-9916-0bc2893898d0",
+    "oracle_id": "bc71ebf6-2056-41f7-be35-b2e5c34afa99",
+    "multiverse_ids": [
+      22361
+    ],
+    "tcgplayer_id": 80202,
+    "cardmarket_id": 14735,
+    "name": "Plains",
+    "lang": "en",
+    "released_at": "1999-11-12",
+    "uri": "https://api.scryfall.com/cards/00298672-079c-4c92-9916-0bc2893898d0",
+    "scryfall_uri": "https://scryfall.com/card/brb/128/plains?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00298672-079c-4c92-9916-0bc2893898d0.jpg?1562895031",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00298672-079c-4c92-9916-0bc2893898d0.jpg?1562895031",
+      "large": "https://cards.scryfall.io/large/front/0/0/00298672-079c-4c92-9916-0bc2893898d0.jpg?1562895031",
+      "png": "https://cards.scryfall.io/png/front/0/0/00298672-079c-4c92-9916-0bc2893898d0.png?1562895031",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00298672-079c-4c92-9916-0bc2893898d0.jpg?1562895031",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00298672-079c-4c92-9916-0bc2893898d0.jpg?1562895031"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Plains",
+    "oracle_text": "({T}: Add {W}.)",
+    "colors": [],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "W"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "81118b2a-b5c8-4fdc-830a-ce5b74eb60b9",
+    "set": "brb",
+    "set_name": "Battle Royale Box Set",
+    "set_type": "box",
+    "set_uri": "https://api.scryfall.com/sets/81118b2a-b5c8-4fdc-830a-ce5b74eb60b9",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Abrb&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/brb?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00298672-079c-4c92-9916-0bc2893898d0/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Abc71ebf6-2056-41f7-be35-b2e5c34afa99&unique=prints",
+    "collector_number": "128",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Douglas Shuler",
+    "artist_ids": [
+      "a9ddb513-51c7-455c-ab8f-5b90aae9f75b"
+    ],
+    "illustration_id": "a8b58b0c-1fef-4064-a35d-1ad1dfe74d83",
+    "border_color": "white",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "0.99",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "1.19",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=22361",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Plains&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Plains&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Plains"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/80202?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Plains&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Plains&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0029955b-32a5-4dd8-8a8c-5c80cdfd13aa",
+    "oracle_id": "9a1de7e4-9930-4db3-a8f3-d146d0abf38b",
+    "multiverse_ids": [
+      382257
+    ],
+    "tcgplayer_id": 83182,
+    "cardmarket_id": 267336,
+    "name": "Edric, Spymaster of Trest",
+    "lang": "en",
+    "released_at": "2014-06-06",
+    "uri": "https://api.scryfall.com/cards/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa",
+    "scryfall_uri": "https://scryfall.com/card/cns/187/edric-spymaster-of-trest?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa.jpg?1562864258",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa.jpg?1562864258",
+      "large": "https://cards.scryfall.io/large/front/0/0/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa.jpg?1562864258",
+      "png": "https://cards.scryfall.io/png/front/0/0/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa.png?1562864258",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa.jpg?1562864258",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa.jpg?1562864258"
+    },
+    "mana_cost": "{1}{G}{U}",
+    "cmc": 3,
+    "type_line": "Legendary Creature — Elf Rogue",
+    "oracle_text": "Whenever a creature deals combat damage to one of your opponents, its controller may draw a card.",
+    "power": "2",
+    "toughness": "2",
+    "colors": [
+      "G",
+      "U"
+    ],
+    "color_identity": [
+      "G",
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "restricted",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "7d4ebb59-a50b-45b8-8fff-ab70767819a5",
+    "set": "cns",
+    "set_name": "Conspiracy",
+    "set_type": "draft_innovation",
+    "set_uri": "https://api.scryfall.com/sets/7d4ebb59-a50b-45b8-8fff-ab70767819a5",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Acns&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/cns?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0029955b-32a5-4dd8-8a8c-5c80cdfd13aa/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A9a1de7e4-9930-4db3-a8f3-d146d0abf38b&unique=prints",
+    "collector_number": "187",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "\"I am not at liberty to reveal my sources, but I can assure you, the price on your head is high.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Volkan Baǵa",
+    "artist_ids": [
+      "93bec3c0-0260-4d31-8064-5d01efb4153f"
+    ],
+    "illustration_id": "83223053-1691-47e9-8e64-54487066aaee",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 2506,
+    "penny_rank": 1070,
+    "prices": {
+      "usd": "2.74",
+      "usd_foil": "9.71",
+      "usd_etched": null,
+      "eur": "2.65",
+      "eur_foil": "9.00",
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=382257",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Edric%2C+Spymaster+of+Trest&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Edric%2C+Spymaster+of+Trest&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Edric%2C+Spymaster+of+Trest"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/83182?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Edric%2C+Spymaster+of+Trest&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Edric%2C+Spymaster+of+Trest&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "002ad179-ddf4-4f48-9504-cfa02e11a52e",
+    "oracle_id": "a755add5-04ec-4e37-9eb6-152d52cfa46d",
+    "multiverse_ids": [],
+    "name": "Clearwater Pathway // Clearwater Pathway",
+    "lang": "en",
+    "released_at": "2020-09-25",
+    "uri": "https://api.scryfall.com/cards/002ad179-ddf4-4f48-9504-cfa02e11a52e",
+    "scryfall_uri": "https://scryfall.com/card/aznr/25/clearwater-pathway-clearwater-pathway?utm_source=api",
+    "layout": "art_series",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "cmc": 0,
+    "type_line": "Card // Card",
+    "color_identity": [],
+    "keywords": [],
+    "card_faces": [
+      {
+        "object": "card_face",
+        "name": "Clearwater Pathway",
+        "mana_cost": "",
+        "type_line": "Card",
+        "oracle_text": "",
+        "colors": [],
+        "artist": "Johannes Voss",
+        "artist_id": "3593dd7e-c547-4a32-81cd-7da725f60118",
+        "illustration_id": "3be0e68b-1bd6-4941-8605-503290443a04",
+        "image_uris": {
+          "small": "https://cards.scryfall.io/small/front/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "normal": "https://cards.scryfall.io/normal/front/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "large": "https://cards.scryfall.io/large/front/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "png": "https://cards.scryfall.io/png/front/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.png?1678735457",
+          "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457"
+        }
+      },
+      {
+        "object": "card_face",
+        "name": "Clearwater Pathway",
+        "flavor_name": "",
+        "mana_cost": "",
+        "type_line": "Card",
+        "oracle_text": "",
+        "colors": [],
+        "artist": "Johannes Voss",
+        "artist_id": "3593dd7e-c547-4a32-81cd-7da725f60118",
+        "illustration_id": "09ad330a-17c5-4c28-a97a-de0562ba2fd8",
+        "image_uris": {
+          "small": "https://cards.scryfall.io/small/back/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "normal": "https://cards.scryfall.io/normal/back/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "large": "https://cards.scryfall.io/large/back/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "png": "https://cards.scryfall.io/png/back/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.png?1678735457",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/0/0/002ad179-ddf4-4f48-9504-cfa02e11a52e.jpg?1678735457"
+        }
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "not_legal",
+      "pauper": "not_legal",
+      "vintage": "not_legal",
+      "penny": "not_legal",
+      "commander": "not_legal",
+      "oathbreaker": "not_legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "not_legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "168acc08-0dea-40e7-ab0d-93bb2832e72b",
+    "set": "aznr",
+    "set_name": "Zendikar Rising Art Series",
+    "set_type": "memorabilia",
+    "set_uri": "https://api.scryfall.com/sets/168acc08-0dea-40e7-ab0d-93bb2832e72b",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aaznr&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/aznr?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/002ad179-ddf4-4f48-9504-cfa02e11a52e/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aa755add5-04ec-4e37-9eb6-152d52cfa46d&unique=prints",
+    "collector_number": "25",
+    "digital": false,
+    "rarity": "common",
+    "artist": "Johannes Voss",
+    "artist_ids": [
+      "3593dd7e-c547-4a32-81cd-7da725f60118"
+    ],
+    "border_color": "borderless",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Clearwater+Pathway+%2F%2F+Clearwater+Pathway&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Clearwater+Pathway+%2F%2F+Clearwater+Pathway&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Clearwater+Pathway"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Clearwater+Pathway&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Clearwater+Pathway&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Clearwater+Pathway&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "002b75fc-c4ba-40fa-9758-8a550e68043b",
+    "oracle_id": "dd99d791-3305-4195-ad12-96d958a28764",
+    "multiverse_ids": [],
+    "tcgplayer_id": 12613,
+    "name": "Crossbow Infantry",
+    "lang": "en",
+    "released_at": "2005-07-29",
+    "uri": "https://api.scryfall.com/cards/002b75fc-c4ba-40fa-9758-8a550e68043b",
+    "scryfall_uri": "https://scryfall.com/card/9ed/12%E2%98%85/crossbow-infantry?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1675829094",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1675829094",
+      "large": "https://cards.scryfall.io/large/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1675829094",
+      "png": "https://cards.scryfall.io/png/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.png?1675829094",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1675829094",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1675829094"
+    },
+    "mana_cost": "{1}{W}",
+    "cmc": 2,
+    "type_line": "Creature — Human Soldier Archer",
+    "oracle_text": "{T}: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": false,
+    "finishes": [
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "e70c8572-4732-4e92-a140-b4e3c1c84c93",
+    "set": "9ed",
+    "set_name": "Ninth Edition",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/e70c8572-4732-4e92-a140-b4e3c1c84c93",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A9ed&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/9ed?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/002b75fc-c4ba-40fa-9758-8a550e68043b/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Add99d791-3305-4195-ad12-96d958a28764&unique=prints",
+    "collector_number": "12★",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"He can split a marshfly in two from halfway across the range.\"\n—Onean sergeant",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "James Bernardin",
+    "artist_ids": [
+      "9b287d6b-17a3-4e6e-8221-5057166fd608"
+    ],
+    "illustration_id": "d6e61d32-faf1-4979-95f2-989ddaa574d0",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 14891,
+    "penny_rank": 11857,
+    "prices": {
+      "usd": null,
+      "usd_foil": "0.47",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Crossbow+Infantry&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Crossbow+Infantry&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Crossbow+Infantry"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/12613?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Crossbow+Infantry&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Crossbow+Infantry&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "002cf7d8-3fc2-48eb-a727-a1ce5a049665",
+    "oracle_id": "75903c3b-2dbe-4662-b6a8-39599e49adde",
+    "multiverse_ids": [
+      15783
+    ],
+    "mtgo_id": 12977,
+    "mtgo_foil_id": 12978,
+    "tcgplayer_id": 6148,
+    "cardmarket_id": 10729,
+    "name": "Bubbling Beebles",
+    "lang": "en",
+    "released_at": "1999-06-07",
+    "uri": "https://api.scryfall.com/cards/002cf7d8-3fc2-48eb-a727-a1ce5a049665",
+    "scryfall_uri": "https://scryfall.com/card/uds/29/bubbling-beebles?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1562443310",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1562443310",
+      "large": "https://cards.scryfall.io/large/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1562443310",
+      "png": "https://cards.scryfall.io/png/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.png?1562443310",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1562443310",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1562443310"
+    },
+    "mana_cost": "{4}{U}",
+    "cmc": 5,
+    "type_line": "Creature — Beeble",
+    "oracle_text": "Bubbling Beebles can't be blocked as long as defending player controls an enchantment.",
+    "power": "3",
+    "toughness": "3",
+    "colors": [
+      "U"
+    ],
+    "color_identity": [
+      "U"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "44f17b37-dcf8-4239-baab-1efc00cd3480",
+    "set": "uds",
+    "set_name": "Urza's Destiny",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/44f17b37-dcf8-4239-baab-1efc00cd3480",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Auds&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/uds?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/002cf7d8-3fc2-48eb-a727-a1ce5a049665/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A75903c3b-2dbe-4662-b6a8-39599e49adde&unique=prints",
+    "collector_number": "29",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"Chancellor Rayne canceled the annual beeble roast. I should have married a crueler woman.\"\n—Barrin",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jeff Miracola",
+    "artist_ids": [
+      "9b465bde-3656-4495-ace4-af4ce29999ed"
+    ],
+    "illustration_id": "abf7c955-713b-4cbf-bf20-22414d5bfdac",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 23415,
+    "penny_rank": 13166,
+    "prices": {
+      "usd": "0.18",
+      "usd_foil": "9.15",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "5.50",
+      "tix": "0.09"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=15783",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Bubbling+Beebles&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Bubbling+Beebles&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Bubbling+Beebles"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/6148?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Bubbling+Beebles&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/12977?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "002f647a-25f8-461b-8617-52674f5d577c",
+    "oracle_id": "bf5f68b8-8ae2-4d08-b86c-4e6d3b653fec",
+    "multiverse_ids": [
+      616859
+    ],
+    "mtgo_id": 111968,
+    "arena_id": 84721,
+    "tcgplayer_id": 498383,
+    "cardmarket_id": 715892,
+    "name": "Second Breakfast",
+    "lang": "en",
+    "released_at": "2023-06-23",
+    "uri": "https://api.scryfall.com/cards/002f647a-25f8-461b-8617-52674f5d577c",
+    "scryfall_uri": "https://scryfall.com/card/ltr/29/second-breakfast?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1686967911",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1686967911",
+      "large": "https://cards.scryfall.io/large/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1686967911",
+      "png": "https://cards.scryfall.io/png/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.png?1686967911",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1686967911",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1686967911"
+    },
+    "mana_cost": "{2}{W}",
+    "cmc": 3,
+    "type_line": "Instant",
+    "oracle_text": "Up to two target creatures each get +2/+1 until end of turn. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [
+      "Food"
+    ],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "e4b7e3b5-2f3c-4eb7-abc9-322a049a9e1a",
+        "component": "token",
+        "name": "Food",
+        "type_line": "Token Artifact — Food",
+        "uri": "https://api.scryfall.com/cards/e4b7e3b5-2f3c-4eb7-abc9-322a049a9e1a"
+      },
+      {
+        "object": "related_card",
+        "id": "002f647a-25f8-461b-8617-52674f5d577c",
+        "component": "combo_piece",
+        "name": "Second Breakfast",
+        "type_line": "Instant",
+        "uri": "https://api.scryfall.com/cards/002f647a-25f8-461b-8617-52674f5d577c"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo",
+      "arena"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "08078706-ac5d-439b-8f01-894d38751367",
+    "set": "ltr",
+    "set_name": "The Lord of the Rings: Tales of Middle-earth",
+    "set_type": "draft_innovation",
+    "set_uri": "https://api.scryfall.com/sets/08078706-ac5d-439b-8f01-894d38751367",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Altr&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ltr?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/002f647a-25f8-461b-8617-52674f5d577c/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Abf5f68b8-8ae2-4d08-b86c-4e6d3b653fec&unique=prints",
+    "collector_number": "29",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "The Hobbits of the Shire were fond of six meals a day—when they could get them.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Christina Kraus",
+    "artist_ids": [
+      "685354c3-302d-486a-b575-cb19bb2c31c9"
+    ],
+    "illustration_id": "2ba517f1-08ef-41ef-9618-33396fba286f",
+    "border_color": "black",
+    "frame": "2015",
+    "security_stamp": "triangle",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 14563,
+    "prices": {
+      "usd": "0.02",
+      "usd_foil": "0.10",
+      "usd_etched": null,
+      "eur": "0.05",
+      "eur_foil": "0.04",
+      "tix": "0.01"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=616859",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Second+Breakfast&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Second+Breakfast&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Second+Breakfast"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/498383?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Second+Breakfast&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/111968?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "002fe870-eae5-42cc-a44c-32906f60719e",
+    "oracle_id": "796f1e1f-7fec-429d-82ae-125f541d6cc7",
+    "multiverse_ids": [
+      571622
+    ],
+    "mtgo_id": 102062,
+    "tcgplayer_id": 277029,
+    "cardmarket_id": 665797,
+    "name": "Ulasht, the Hate Seed",
+    "lang": "en",
+    "released_at": "2022-07-08",
+    "uri": "https://api.scryfall.com/cards/002fe870-eae5-42cc-a44c-32906f60719e",
+    "scryfall_uri": "https://scryfall.com/card/2x2/289/ulasht-the-hate-seed?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1673149236",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1673149236",
+      "large": "https://cards.scryfall.io/large/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1673149236",
+      "png": "https://cards.scryfall.io/png/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.png?1673149236",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1673149236",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1673149236"
+    },
+    "mana_cost": "{2}{R}{G}",
+    "cmc": 4,
+    "type_line": "Legendary Creature — Hellion Hydra",
+    "oracle_text": "Ulasht, the Hate Seed enters the battlefield with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one —\n• Ulasht deals 1 damage to target creature.\n• Create a 1/1 green Saproling creature token.",
+    "power": "0",
+    "toughness": "0",
+    "colors": [
+      "G",
+      "R"
+    ],
+    "color_identity": [
+      "G",
+      "R"
+    ],
+    "keywords": [],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "b2c9bcf4-4e8c-467c-8c72-4a9cd0556e93",
+        "component": "token",
+        "name": "Saproling",
+        "type_line": "Token Creature — Saproling",
+        "uri": "https://api.scryfall.com/cards/b2c9bcf4-4e8c-467c-8c72-4a9cd0556e93"
+      },
+      {
+        "object": "related_card",
+        "id": "8ecb8a87-85d9-48ae-b0b3-84b9420ae082",
+        "component": "combo_piece",
+        "name": "Ulasht, the Hate Seed",
+        "type_line": "Legendary Creature — Hellion Hydra",
+        "uri": "https://api.scryfall.com/cards/8ecb8a87-85d9-48ae-b0b3-84b9420ae082"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "5a645837-b050-449f-ac90-1e7ccbf45031",
+    "set": "2x2",
+    "set_name": "Double Masters 2022",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/5a645837-b050-449f-ac90-1e7ccbf45031",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A2x2&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/2x2?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/002fe870-eae5-42cc-a44c-32906f60719e/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A796f1e1f-7fec-429d-82ae-125f541d6cc7&unique=prints",
+    "collector_number": "289",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Nottsuo",
+    "artist_ids": [
+      "78ae4348-24fb-401f-bfba-0d5c34c106ab"
+    ],
+    "illustration_id": "b1ba816e-f123-4355-97e6-e09ab8cd6646",
+    "border_color": "black",
+    "frame": "2015",
+    "frame_effects": [
+      "legendary"
+    ],
+    "security_stamp": "oval",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 7167,
+    "penny_rank": 13359,
+    "preview": {
+      "source": "Amy the Amazonian",
+      "source_uri": "https://twitter.com/coL_Amazonian/status/1539990752457113600",
+      "previewed_at": "2022-06-23"
+    },
+    "prices": {
+      "usd": "0.13",
+      "usd_foil": "0.26",
+      "usd_etched": null,
+      "eur": "0.19",
+      "eur_foil": "0.25",
+      "tix": "0.02"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=571622",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Ulasht%2C+the+Hate+Seed&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Ulasht%2C+the+Hate+Seed&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Ulasht%2C+the+Hate+Seed"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/277029?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Ulasht%2C+the+Hate+Seed&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/102062?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0030407c-9aa0-49ad-b2d6-cde0adbd9d09",
+    "oracle_id": "090d88a9-7f2d-4bd1-a30a-7c48d05068be",
+    "multiverse_ids": [
+      15821
+    ],
+    "mtgo_id": 15948,
+    "mtgo_foil_id": 15949,
+    "tcgplayer_id": 3131,
+    "cardmarket_id": 2930,
+    "name": "Unholy Strength",
+    "lang": "en",
+    "released_at": "2001-04-11",
+    "uri": "https://api.scryfall.com/cards/0030407c-9aa0-49ad-b2d6-cde0adbd9d09",
+    "scryfall_uri": "https://scryfall.com/card/7ed/168/unholy-strength?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1562231343",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1562231343",
+      "large": "https://cards.scryfall.io/large/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1562231343",
+      "png": "https://cards.scryfall.io/png/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.png?1562231343",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1562231343",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1562231343"
+    },
+    "mana_cost": "{B}",
+    "cmc": 1,
+    "type_line": "Enchantment — Aura",
+    "oracle_text": "Enchant creature\nEnchanted creature gets +2/+1.",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [
+      "Enchant"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "230f38aa-9511-4db8-a3aa-aeddbc3f7bb9",
+    "set": "7ed",
+    "set_name": "Seventh Edition",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/230f38aa-9511-4db8-a3aa-aeddbc3f7bb9",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3A7ed&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/7ed?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0030407c-9aa0-49ad-b2d6-cde0adbd9d09/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A090d88a9-7f2d-4bd1-a30a-7c48d05068be&unique=prints",
+    "collector_number": "168",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "\"I don't *feel* any different.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Gary Ruddell",
+    "artist_ids": [
+      "086111c7-93f0-4bab-b339-6fe1c00d693c"
+    ],
+    "illustration_id": "c977dafe-a3c9-4295-b42e-79a405f85789",
+    "border_color": "white",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 15850,
+    "penny_rank": 10543,
+    "prices": {
+      "usd": "0.12",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.03",
+      "eur_foil": null,
+      "tix": "0.11"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=15821",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Unholy+Strength&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Unholy+Strength&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Unholy+Strength"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/3131?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Unholy+Strength&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/15948?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0031d026-9e9a-46f6-8204-1acfee8b8809",
+    "oracle_id": "b34bb2dc-c1af-4d77-b0b3-a0fb342a5fc6",
+    "multiverse_ids": [],
+    "tcgplayer_id": 173843,
+    "name": "Forest",
+    "lang": "en",
+    "released_at": "2002-08-14",
+    "uri": "https://api.scryfall.com/cards/0031d026-9e9a-46f6-8204-1acfee8b8809",
+    "scryfall_uri": "https://scryfall.com/card/wc02/rl349/forest?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0031d026-9e9a-46f6-8204-1acfee8b8809.jpg?1561894880",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0031d026-9e9a-46f6-8204-1acfee8b8809.jpg?1561894880",
+      "large": "https://cards.scryfall.io/large/front/0/0/0031d026-9e9a-46f6-8204-1acfee8b8809.jpg?1561894880",
+      "png": "https://cards.scryfall.io/png/front/0/0/0031d026-9e9a-46f6-8204-1acfee8b8809.png?1561894880",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0031d026-9e9a-46f6-8204-1acfee8b8809.jpg?1561894880",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0031d026-9e9a-46f6-8204-1acfee8b8809.jpg?1561894880"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Basic Land — Forest",
+    "oracle_text": "({T}: Add {G}.)",
+    "colors": [],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "G"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "04dfc9bb-ccaa-436c-b79a-925b2ad9bdbe",
+    "set": "wc02",
+    "set_name": "World Championship Decks 2002",
+    "set_type": "memorabilia",
+    "set_uri": "https://api.scryfall.com/sets/04dfc9bb-ccaa-436c-b79a-925b2ad9bdbe",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Awc02&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/wc02?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0031d026-9e9a-46f6-8204-1acfee8b8809/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ab34bb2dc-c1af-4d77-b0b3-a0fb342a5fc6&unique=prints",
+    "collector_number": "rl349",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "6bcbb89c-0af2-4510-8484-e59cc0042b09",
+    "artist": "Jerry Tiritilli",
+    "artist_ids": [
+      "54366fc1-c5b1-4faa-a7a5-de2abc119de1"
+    ],
+    "illustration_id": "841730ec-dec8-4dcd-8f88-687515817e35",
+    "border_color": "gold",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Forest&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Forest&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Forest"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/173843?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Forest&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Forest&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00320106-ce51-46a9-b0f9-79b3baf4e505",
+    "oracle_id": "20e7a93f-77ce-466b-8586-35d390689d0c",
+    "multiverse_ids": [
+      457368
+    ],
+    "mtgo_id": 71464,
+    "arena_id": 69358,
+    "tcgplayer_id": 183063,
+    "cardmarket_id": 368154,
+    "name": "Consecrate // Consume",
+    "lang": "en",
+    "released_at": "2019-01-25",
+    "uri": "https://api.scryfall.com/cards/00320106-ce51-46a9-b0f9-79b3baf4e505",
+    "scryfall_uri": "https://scryfall.com/card/rna/224/consecrate-consume?utm_source=api",
+    "layout": "split",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1584832033",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1584832033",
+      "large": "https://cards.scryfall.io/large/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1584832033",
+      "png": "https://cards.scryfall.io/png/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.png?1584832033",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1584832033",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1584832033"
+    },
+    "mana_cost": "{1}{W/B} // {2}{W}{B}",
+    "cmc": 6,
+    "type_line": "Instant // Sorcery",
+    "colors": [
+      "B",
+      "W"
+    ],
+    "color_identity": [
+      "B",
+      "W"
+    ],
+    "keywords": [],
+    "card_faces": [
+      {
+        "object": "card_face",
+        "name": "Consecrate",
+        "mana_cost": "{1}{W/B}",
+        "type_line": "Instant",
+        "oracle_text": "Exile target card from a graveyard.\nDraw a card.",
+        "watermark": "orzhov",
+        "artist": "Igor Kieryluk",
+        "artist_id": "9c3e9d17-509f-485c-9360-46d897ce716b",
+        "illustration_id": "a0cc2a18-34cd-4044-ae73-bef0cf498317"
+      },
+      {
+        "object": "card_face",
+        "name": "Consume",
+        "flavor_name": "",
+        "mana_cost": "{2}{W}{B}",
+        "type_line": "Sorcery",
+        "oracle_text": "Target player sacrifices a creature with the greatest power among creatures they control. You gain life equal to its power.",
+        "artist": "Igor Kieryluk",
+        "artist_id": "9c3e9d17-509f-485c-9360-46d897ce716b"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "arena",
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "97a7fd84-8d89-45a3-b48b-c951f6a3f9f1",
+    "set": "rna",
+    "set_name": "Ravnica Allegiance",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/97a7fd84-8d89-45a3-b48b-c951f6a3f9f1",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Arna&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/rna?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00320106-ce51-46a9-b0f9-79b3baf4e505/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A20e7a93f-77ce-466b-8586-35d390689d0c&unique=prints",
+    "collector_number": "224",
+    "digital": false,
+    "rarity": "uncommon",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Igor Kieryluk",
+    "artist_ids": [
+      "9c3e9d17-509f-485c-9360-46d897ce716b"
+    ],
+    "illustration_id": "a0cc2a18-34cd-4044-ae73-bef0cf498317",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 13122,
+    "penny_rank": 4214,
+    "preview": {
+      "source": "Crestongames",
+      "source_uri": "https://www.twitch.tv/videos/358331828",
+      "previewed_at": "2019-01-03"
+    },
+    "prices": {
+      "usd": "0.07",
+      "usd_foil": "0.27",
+      "usd_etched": null,
+      "eur": "0.02",
+      "eur_foil": "0.18",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=457368",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Consecrate+%2F%2F+Consume&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Consecrate+%2F%2F+Consume&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Consecrate+%2F%2F+Consume"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/183063?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Consecrate+%2F%2F+Consume&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/71464?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00323a16-8bfd-49af-b073-8f0b23a9d947",
+    "oracle_id": "ec96cde2-f1e6-495c-94e2-3e8ae79e556c",
+    "multiverse_ids": [
+      413788
+    ],
+    "mtgo_id": 60863,
+    "mtgo_foil_id": 60864,
+    "tcgplayer_id": 118628,
+    "cardmarket_id": 290485,
+    "name": "Thornwood Falls",
+    "lang": "en",
+    "released_at": "2016-06-10",
+    "uri": "https://api.scryfall.com/cards/00323a16-8bfd-49af-b073-8f0b23a9d947",
+    "scryfall_uri": "https://scryfall.com/card/ema/246/thornwood-falls?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1580015367",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1580015367",
+      "large": "https://cards.scryfall.io/large/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1580015367",
+      "png": "https://cards.scryfall.io/png/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.png?1580015367",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1580015367",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1580015367"
+    },
+    "mana_cost": "",
+    "cmc": 0,
+    "type_line": "Land",
+    "oracle_text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
+    "colors": [],
+    "color_identity": [
+      "G",
+      "U"
+    ],
+    "keywords": [],
+    "produced_mana": [
+      "G",
+      "U"
+    ],
+    "legalities": {
+      "standard": "legal",
+      "future": "legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "1f29f022-3ace-4c96-85e8-1f7b63aadf7e",
+    "set": "ema",
+    "set_name": "Eternal Masters",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/1f29f022-3ace-4c96-85e8-1f7b63aadf7e",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aema&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ema?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00323a16-8bfd-49af-b073-8f0b23a9d947/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aec96cde2-f1e6-495c-94e2-3e8ae79e556c&unique=prints",
+    "collector_number": "246",
+    "digital": false,
+    "rarity": "common",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Eytan Zana",
+    "artist_ids": [
+      "0d8d6726-4051-445a-8374-a919aad98f38"
+    ],
+    "illustration_id": "7541110c-078d-4c48-87a0-df814ec582f6",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 828,
+    "penny_rank": 474,
+    "prices": {
+      "usd": "0.06",
+      "usd_foil": "0.18",
+      "usd_etched": null,
+      "eur": "0.10",
+      "eur_foil": "0.10",
+      "tix": "0.05"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=413788",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Thornwood+Falls&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Thornwood+Falls&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Thornwood+Falls"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/118628?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Thornwood+Falls&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/60863?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00325992-ec1c-469a-8df0-ffb9a197d221",
+    "oracle_id": "29d6b745-97be-4f38-88f7-9408302aae74",
+    "multiverse_ids": [
+      9666
+    ],
+    "tcgplayer_id": 864,
+    "cardmarket_id": 11904,
+    "name": "Goblin Bowling Team",
+    "lang": "en",
+    "released_at": "1998-08-11",
+    "uri": "https://api.scryfall.com/cards/00325992-ec1c-469a-8df0-ffb9a197d221",
+    "scryfall_uri": "https://scryfall.com/card/ugl/44/goblin-bowling-team?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1562799056",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1562799056",
+      "large": "https://cards.scryfall.io/large/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1562799056",
+      "png": "https://cards.scryfall.io/png/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.png?1562799056",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1562799056",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1562799056"
+    },
+    "mana_cost": "{3}{R}",
+    "cmc": 4,
+    "type_line": "Creature — Goblin",
+    "oracle_text": "If Goblin Bowling Team would deal damage to a permanent or player, it deals that much damage plus the result of a six-sided die roll to that permanent or player instead.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "not_legal",
+      "pauper": "not_legal",
+      "vintage": "not_legal",
+      "penny": "not_legal",
+      "commander": "not_legal",
+      "oathbreaker": "not_legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "not_legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "3404fc78-6678-4cf4-bd39-4c0be3bb7baf",
+    "set": "ugl",
+    "set_name": "Unglued",
+    "set_type": "funny",
+    "set_uri": "https://api.scryfall.com/sets/3404fc78-6678-4cf4-bd39-4c0be3bb7baf",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Augl&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/ugl?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00325992-ec1c-469a-8df0-ffb9a197d221/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A29d6b745-97be-4f38-88f7-9408302aae74&unique=prints",
+    "collector_number": "44",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "Flog was out of his league—this game wasn't up his alley, but the team couldn't spare him if he split.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Pete Venters",
+    "artist_ids": [
+      "d54c4a1a-c0c5-4834-84db-125d341f3ad8"
+    ],
+    "illustration_id": "ce0bf977-6b61-4e6a-a69c-e1f3bf85417a",
+    "border_color": "silver",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "prices": {
+      "usd": "0.20",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.25",
+      "eur_foil": null,
+      "tix": null
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=9666",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Goblin+Bowling+Team&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Goblin+Bowling+Team&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Goblin+Bowling+Team"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/864?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Goblin+Bowling+Team&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Goblin+Bowling+Team&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0032a2ab-a385-47e4-843b-1ac677032dc4",
+    "oracle_id": "1d25b831-c1de-4f79-bbb3-1582eda96452",
+    "multiverse_ids": [],
+    "tcgplayer_id": 37979,
+    "cardmarket_id": 18212,
+    "name": "Elvish Aberration",
+    "lang": "en",
+    "released_at": "2003-01-01",
+    "uri": "https://api.scryfall.com/cards/0032a2ab-a385-47e4-843b-1ac677032dc4",
+    "scryfall_uri": "https://scryfall.com/card/pal03/7/elvish-aberration?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0032a2ab-a385-47e4-843b-1ac677032dc4.jpg?1561756565",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0032a2ab-a385-47e4-843b-1ac677032dc4.jpg?1561756565",
+      "large": "https://cards.scryfall.io/large/front/0/0/0032a2ab-a385-47e4-843b-1ac677032dc4.jpg?1561756565",
+      "png": "https://cards.scryfall.io/png/front/0/0/0032a2ab-a385-47e4-843b-1ac677032dc4.png?1561756565",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0032a2ab-a385-47e4-843b-1ac677032dc4.jpg?1561756565",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0032a2ab-a385-47e4-843b-1ac677032dc4.jpg?1561756565"
+    },
+    "mana_cost": "{5}{G}",
+    "cmc": 6,
+    "type_line": "Creature — Elf Mutant",
+    "oracle_text": "{T}: Add {G}{G}{G}.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
+    "power": "4",
+    "toughness": "5",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [
+      "Landcycling",
+      "Forestcycling",
+      "Typecycling",
+      "Cycling"
+    ],
+    "produced_mana": [
+      "G"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": false,
+    "finishes": [
+      "foil"
+    ],
+    "oversized": false,
+    "promo": true,
+    "reprint": true,
+    "variation": false,
+    "set_id": "bf8bc347-ae11-43d4-98da-3625566668dd",
+    "set": "pal03",
+    "set_name": "Arena League 2003",
+    "set_type": "promo",
+    "set_uri": "https://api.scryfall.com/sets/bf8bc347-ae11-43d4-98da-3625566668dd",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Apal03&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/pal03?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0032a2ab-a385-47e4-843b-1ac677032dc4/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A1d25b831-c1de-4f79-bbb3-1582eda96452&unique=prints",
+    "collector_number": "7",
+    "digital": false,
+    "rarity": "rare",
+    "watermark": "arena",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Matt Cavotta",
+    "artist_ids": [
+      "2e6a0611-9411-4ba4-98e3-c0e18cbf9f83"
+    ],
+    "illustration_id": "153b3e20-a142-4065-a40a-16e8722812d7",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "promo_types": [
+      "arenaleague"
+    ],
+    "edhrec_rank": 8825,
+    "penny_rank": 6948,
+    "prices": {
+      "usd": null,
+      "usd_foil": "0.99",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": "0.75",
+      "tix": null
+    },
+    "related_uris": {
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Elvish+Aberration&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Elvish+Aberration&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Elvish+Aberration"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/37979?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Elvish+Aberration&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Elvish+Aberration&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "003367c7-6cb8-4451-8349-76ce5d21e367",
+    "oracle_id": "83cb9ab7-6a8f-40b5-b076-6fa669ff15f2",
+    "multiverse_ids": [
+      588408
+    ],
+    "mtgo_id": 105234,
+    "tcgplayer_id": 452142,
+    "cardmarket_id": 682744,
+    "name": "Farid, Enterprising Salvager",
+    "lang": "en",
+    "released_at": "2022-11-18",
+    "uri": "https://api.scryfall.com/cards/003367c7-6cb8-4451-8349-76ce5d21e367",
+    "scryfall_uri": "https://scryfall.com/card/brc/13/farid-enterprising-salvager?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.jpg?1688125556",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.jpg?1688125556",
+      "large": "https://cards.scryfall.io/large/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.jpg?1688125556",
+      "png": "https://cards.scryfall.io/png/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.png?1688125556",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.jpg?1688125556",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.jpg?1688125556"
+    },
+    "mana_cost": "{2}{R}",
+    "cmc": 3,
+    "type_line": "Legendary Creature — Human Soldier",
+    "oracle_text": "Whenever a nontoken artifact you control is put into a graveyard from the battlefield, create a colorless artifact token named Scrap.\n{1}{R}, Sacrifice an artifact: Choose one —\n• Put a +1/+1 counter on Farid. It gains menace until end of turn.\n• Goad target creature.\n• Discard a card, then draw a card.",
+    "power": "3",
+    "toughness": "3",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [
+      "Goad"
+    ],
+    "all_parts": [
+      {
+        "object": "related_card",
+        "id": "f36fdf0d-035d-4313-87f5-4a2502a20518",
+        "component": "token",
+        "name": "Scrap",
+        "type_line": "Token Artifact",
+        "uri": "https://api.scryfall.com/cards/f36fdf0d-035d-4313-87f5-4a2502a20518"
+      },
+      {
+        "object": "related_card",
+        "id": "59732d7d-2afc-4460-a9e3-e94080c7d42f",
+        "component": "combo_piece",
+        "name": "Farid, Enterprising Salvager",
+        "type_line": "Legendary Creature — Human Soldier",
+        "uri": "https://api.scryfall.com/cards/59732d7d-2afc-4460-a9e3-e94080c7d42f"
+      }
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "81d56780-1efc-4487-9803-43d634ca13d0",
+    "set": "brc",
+    "set_name": "The Brothers' War Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/81d56780-1efc-4487-9803-43d634ca13d0",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Abrc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/brc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/003367c7-6cb8-4451-8349-76ce5d21e367/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A83cb9ab7-6a8f-40b5-b076-6fa669ff15f2&unique=prints",
+    "collector_number": "13",
+    "digital": false,
+    "rarity": "rare",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Bruno Biazotto",
+    "artist_ids": [
+      "18947a30-a1b4-4b0d-979e-ef1f2a080f35"
+    ],
+    "illustration_id": "87b71013-05fb-4750-8b6e-b38407a285e7",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 8549,
+    "prices": {
+      "usd": "0.12",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.22",
+      "eur_foil": null,
+      "tix": "0.28"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=588408",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Farid%2C+Enterprising+Salvager&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Farid%2C+Enterprising+Salvager&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Farid%2C+Enterprising+Salvager"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/452142?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Farid%2C+Enterprising+Salvager&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/105234?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00341664-d848-44d2-ba06-21a6ae8e6788",
+    "oracle_id": "06413d87-d119-4c04-93d5-5ced7ad4a858",
+    "multiverse_ids": [
+      184628
+    ],
+    "mtgo_id": 30598,
+    "mtgo_foil_id": 30599,
+    "name": "Wings of Aesthir",
+    "lang": "en",
+    "released_at": "2008-09-22",
+    "uri": "https://api.scryfall.com/cards/00341664-d848-44d2-ba06-21a6ae8e6788",
+    "scryfall_uri": "https://scryfall.com/card/me2/199/wings-of-aesthir?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00341664-d848-44d2-ba06-21a6ae8e6788.jpg?1562867376",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00341664-d848-44d2-ba06-21a6ae8e6788.jpg?1562867376",
+      "large": "https://cards.scryfall.io/large/front/0/0/00341664-d848-44d2-ba06-21a6ae8e6788.jpg?1562867376",
+      "png": "https://cards.scryfall.io/png/front/0/0/00341664-d848-44d2-ba06-21a6ae8e6788.png?1562867376",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00341664-d848-44d2-ba06-21a6ae8e6788.jpg?1562867376",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00341664-d848-44d2-ba06-21a6ae8e6788.jpg?1562867376"
+    },
+    "mana_cost": "{W}{U}",
+    "cmc": 2,
+    "type_line": "Enchantment — Aura",
+    "oracle_text": "Enchant creature\nEnchanted creature gets +1/+0 and has flying and first strike.",
+    "colors": [
+      "U",
+      "W"
+    ],
+    "color_identity": [
+      "U",
+      "W"
+    ],
+    "keywords": [
+      "Enchant"
+    ],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "not_legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "not_legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "7d51a13b-dcd2-4ec2-b3a7-c89288e00b4e",
+    "set": "me2",
+    "set_name": "Masters Edition II",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/7d51a13b-dcd2-4ec2-b3a7-c89288e00b4e",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ame2&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/me2?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00341664-d848-44d2-ba06-21a6ae8e6788/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A06413d87-d119-4c04-93d5-5ced7ad4a858&unique=prints",
+    "collector_number": "199",
+    "digital": true,
+    "rarity": "uncommon",
+    "flavor_text": "\"For those of courage, even the sky holds no limit.\"\n—Arnjlot Olasson, sky mage",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Edward P. Beard, Jr.",
+    "artist_ids": [
+      "b845b8ee-aeea-4822-bcf9-7230625ac95c"
+    ],
+    "illustration_id": "5890749a-fbc2-4f16-99ec-67db7ade1d25",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 22737,
+    "penny_rank": 12946,
+    "prices": {
+      "usd": null,
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": "0.06"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=184628",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Wings+of+Aesthir&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Wings+of+Aesthir&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Wings+of+Aesthir"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/search/magic/product?productLineName=magic&q=Wings+of+Aesthir&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall&view=grid",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Wings+of+Aesthir&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/30598?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0034d32c-cc82-48d7-a913-d58cc3d3afeb",
+    "oracle_id": "b6265654-84c3-469b-9afa-f752fd64abe0",
+    "multiverse_ids": [
+      249699
+    ],
+    "mtgo_id": 45682,
+    "mtgo_foil_id": 45683,
+    "tcgplayer_id": 59821,
+    "cardmarket_id": 256795,
+    "name": "Mwonvuli Beast Tracker",
+    "lang": "en",
+    "released_at": "2012-07-13",
+    "uri": "https://api.scryfall.com/cards/0034d32c-cc82-48d7-a913-d58cc3d3afeb",
+    "scryfall_uri": "https://scryfall.com/card/m13/177/mwonvuli-beast-tracker?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1591694417",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1591694417",
+      "large": "https://cards.scryfall.io/large/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1591694417",
+      "png": "https://cards.scryfall.io/png/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.png?1591694417",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1591694417",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1591694417"
+    },
+    "mana_cost": "{1}{G}{G}",
+    "cmc": 3,
+    "type_line": "Creature — Human Scout",
+    "oracle_text": "When Mwonvuli Beast Tracker enters the battlefield, search your library for a creature card with deathtouch, hexproof, reach, or trample and reveal it. Shuffle and put that card on top.",
+    "power": "2",
+    "toughness": "1",
+    "colors": [
+      "G"
+    ],
+    "color_identity": [
+      "G"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "restricted",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "not_legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": false,
+    "variation": false,
+    "set_id": "f9b0c6f4-8a4f-4f36-ad3c-e1e16fb8535d",
+    "set": "m13",
+    "set_name": "Magic 2013",
+    "set_type": "core",
+    "set_uri": "https://api.scryfall.com/sets/f9b0c6f4-8a4f-4f36-ad3c-e1e16fb8535d",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Am13&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/m13?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0034d32c-cc82-48d7-a913-d58cc3d3afeb/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ab6265654-84c3-469b-9afa-f752fd64abe0&unique=prints",
+    "collector_number": "177",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "\"The more dangerous, the better.\"",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Zoltan Boros",
+    "artist_ids": [
+      "1885e6cb-c827-4896-994e-3d0a027d602f"
+    ],
+    "illustration_id": "d26a404c-c0b7-430d-a164-9bbe57076c4f",
+    "border_color": "black",
+    "frame": "2003",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 6814,
+    "penny_rank": 7805,
+    "prices": {
+      "usd": "0.19",
+      "usd_foil": "0.98",
+      "usd_etched": null,
+      "eur": "0.23",
+      "eur_foil": "0.75",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=249699",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Mwonvuli+Beast+Tracker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Mwonvuli+Beast+Tracker&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Mwonvuli+Beast+Tracker"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/59821?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Mwonvuli+Beast+Tracker&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/45682?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0034ed95-a296-44c1-a084-e03c57c1865f",
+    "oracle_id": "3029df1d-d02a-4fed-8ab4-000a2096f823",
+    "multiverse_ids": [
+      508322
+    ],
+    "mtgo_id": 87969,
+    "tcgplayer_id": 231274,
+    "cardmarket_id": 535163,
+    "name": "Return to Dust",
+    "lang": "en",
+    "released_at": "2021-02-05",
+    "uri": "https://api.scryfall.com/cards/0034ed95-a296-44c1-a084-e03c57c1865f",
+    "scryfall_uri": "https://scryfall.com/card/khc/32/return-to-dust?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0034ed95-a296-44c1-a084-e03c57c1865f.jpg?1631234174",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0034ed95-a296-44c1-a084-e03c57c1865f.jpg?1631234174",
+      "large": "https://cards.scryfall.io/large/front/0/0/0034ed95-a296-44c1-a084-e03c57c1865f.jpg?1631234174",
+      "png": "https://cards.scryfall.io/png/front/0/0/0034ed95-a296-44c1-a084-e03c57c1865f.png?1631234174",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0034ed95-a296-44c1-a084-e03c57c1865f.jpg?1631234174",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0034ed95-a296-44c1-a084-e03c57c1865f.jpg?1631234174"
+    },
+    "mana_cost": "{2}{W}{W}",
+    "cmc": 4,
+    "type_line": "Instant",
+    "oracle_text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
+    "colors": [
+      "W"
+    ],
+    "color_identity": [
+      "W"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": false,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "d532ef25-e52b-4276-941a-3a1c095544b0",
+    "set": "khc",
+    "set_name": "Kaldheim Commander",
+    "set_type": "commander",
+    "set_uri": "https://api.scryfall.com/sets/d532ef25-e52b-4276-941a-3a1c095544b0",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Akhc&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/khc?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0034ed95-a296-44c1-a084-e03c57c1865f/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A3029df1d-d02a-4fed-8ab4-000a2096f823&unique=prints",
+    "collector_number": "32",
+    "digital": false,
+    "rarity": "uncommon",
+    "flavor_text": "Some timelines forever fray, branch, and intermingle. Others end abruptly.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Wayne Reynolds",
+    "artist_ids": [
+      "afc47cec-3ccc-404e-a8c6-4d83dd504271"
+    ],
+    "illustration_id": "d39e220c-6bfb-412b-802b-2343901947bb",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": false,
+    "story_spotlight": false,
+    "edhrec_rank": 458,
+    "penny_rank": 9922,
+    "prices": {
+      "usd": "0.11",
+      "usd_foil": null,
+      "usd_etched": null,
+      "eur": "0.17",
+      "eur_foil": null,
+      "tix": "0.04"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=508322",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Return+to+Dust&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Return+to+Dust&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Return+to+Dust"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/231274?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Return+to+Dust&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/87969?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "0035cade-d84c-4978-8c9f-560893f07c27",
+    "oracle_id": "9ed6f28f-a3db-48c5-9ab0-b90a7fba5f57",
+    "multiverse_ids": [
+      601379
+    ],
+    "mtgo_id": 107305,
+    "tcgplayer_id": 457187,
+    "name": "Royal Assassin",
+    "lang": "en",
+    "released_at": "2023-01-13",
+    "uri": "https://api.scryfall.com/cards/0035cade-d84c-4978-8c9f-560893f07c27",
+    "scryfall_uri": "https://scryfall.com/card/dmr/310/royal-assassin?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1675201829",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1675201829",
+      "large": "https://cards.scryfall.io/large/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1675201829",
+      "png": "https://cards.scryfall.io/png/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.png?1675201829",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1675201829",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1675201829"
+    },
+    "mana_cost": "{1}{B}{B}",
+    "cmc": 3,
+    "type_line": "Creature — Human Assassin",
+    "oracle_text": "{T}: Destroy target tapped creature.",
+    "power": "1",
+    "toughness": "1",
+    "colors": [
+      "B"
+    ],
+    "color_identity": [
+      "B"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "not_legal",
+      "gladiator": "not_legal",
+      "pioneer": "not_legal",
+      "explorer": "not_legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "not_legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "not_legal",
+      "alchemy": "not_legal",
+      "paupercommander": "not_legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "ca4c2884-e539-4b7f-980d-5d6a50220f2a",
+    "set": "dmr",
+    "set_name": "Dominaria Remastered",
+    "set_type": "masters",
+    "set_uri": "https://api.scryfall.com/sets/ca4c2884-e539-4b7f-980d-5d6a50220f2a",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Admr&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/dmr?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/0035cade-d84c-4978-8c9f-560893f07c27/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A9ed6f28f-a3db-48c5-9ab0-b90a7fba5f57&unique=prints",
+    "collector_number": "310",
+    "digital": false,
+    "rarity": "rare",
+    "flavor_text": "An assassin is a king's most trusted courier, ensuring his messages are heard by even the most unwilling recipients.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Mark Zug",
+    "artist_ids": [
+      "48e2b98c-5467-4671-bd42-4c3746115117"
+    ],
+    "illustration_id": "6c24a711-fc33-4cd0-9fe8-a4dca296a0a6",
+    "border_color": "black",
+    "frame": "1997",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 2859,
+    "penny_rank": 5535,
+    "prices": {
+      "usd": "0.53",
+      "usd_foil": "0.91",
+      "usd_etched": null,
+      "eur": null,
+      "eur_foil": null,
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=601379",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Royal+Assassin&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Royal+Assassin&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Royal+Assassin"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/457187?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Royal+Assassin&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/107305?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  },
+  {
+    "object": "card",
+    "id": "00365412-41db-427c-9109-8f69c17c326d",
+    "oracle_id": "a9d288b8-cdc1-4e55-a0c9-d6edfc95e65d",
+    "multiverse_ids": [
+      423765
+    ],
+    "mtgo_id": 62923,
+    "mtgo_foil_id": 62924,
+    "tcgplayer_id": 126437,
+    "cardmarket_id": 294825,
+    "name": "Shock",
+    "lang": "en",
+    "released_at": "2017-01-20",
+    "uri": "https://api.scryfall.com/cards/00365412-41db-427c-9109-8f69c17c326d",
+    "scryfall_uri": "https://scryfall.com/card/aer/98/shock?utm_source=api",
+    "layout": "normal",
+    "highres_image": true,
+    "image_status": "highres_scan",
+    "image_uris": {
+      "small": "https://cards.scryfall.io/small/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1576381909",
+      "normal": "https://cards.scryfall.io/normal/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1576381909",
+      "large": "https://cards.scryfall.io/large/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1576381909",
+      "png": "https://cards.scryfall.io/png/front/0/0/00365412-41db-427c-9109-8f69c17c326d.png?1576381909",
+      "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1576381909",
+      "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1576381909"
+    },
+    "mana_cost": "{R}",
+    "cmc": 1,
+    "type_line": "Instant",
+    "oracle_text": "Shock deals 2 damage to any target.",
+    "colors": [
+      "R"
+    ],
+    "color_identity": [
+      "R"
+    ],
+    "keywords": [],
+    "legalities": {
+      "standard": "not_legal",
+      "future": "not_legal",
+      "historic": "legal",
+      "gladiator": "legal",
+      "pioneer": "legal",
+      "explorer": "legal",
+      "modern": "legal",
+      "legacy": "legal",
+      "pauper": "legal",
+      "vintage": "legal",
+      "penny": "legal",
+      "commander": "legal",
+      "oathbreaker": "legal",
+      "brawl": "not_legal",
+      "historicbrawl": "legal",
+      "alchemy": "legal",
+      "paupercommander": "legal",
+      "duel": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "predh": "legal"
+    },
+    "games": [
+      "paper",
+      "mtgo"
+    ],
+    "reserved": false,
+    "foil": true,
+    "nonfoil": true,
+    "finishes": [
+      "nonfoil",
+      "foil"
+    ],
+    "oversized": false,
+    "promo": false,
+    "reprint": true,
+    "variation": false,
+    "set_id": "a4a0db50-8826-4e73-833c-3fd934375f96",
+    "set": "aer",
+    "set_name": "Aether Revolt",
+    "set_type": "expansion",
+    "set_uri": "https://api.scryfall.com/sets/a4a0db50-8826-4e73-833c-3fd934375f96",
+    "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aaer&unique=prints",
+    "scryfall_set_uri": "https://scryfall.com/sets/aer?utm_source=api",
+    "rulings_uri": "https://api.scryfall.com/cards/00365412-41db-427c-9109-8f69c17c326d/rulings",
+    "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aa9d288b8-cdc1-4e55-a0c9-d6edfc95e65d&unique=prints",
+    "collector_number": "98",
+    "digital": false,
+    "rarity": "common",
+    "flavor_text": "The tools of invention became the weapons of revolution.",
+    "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+    "artist": "Jason Rainville",
+    "artist_ids": [
+      "6ed7e669-579b-443d-b223-e5cbcb2a7483"
+    ],
+    "illustration_id": "167dac35-21f6-4174-b496-4b66ffd980b1",
+    "border_color": "black",
+    "frame": "2015",
+    "full_art": false,
+    "textless": false,
+    "booster": true,
+    "story_spotlight": false,
+    "edhrec_rank": 3000,
+    "penny_rank": 1015,
+    "prices": {
+      "usd": "0.05",
+      "usd_foil": "0.23",
+      "usd_etched": null,
+      "eur": "0.09",
+      "eur_foil": "0.52",
+      "tix": "0.03"
+    },
+    "related_uris": {
+      "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=423765",
+      "tcgplayer_infinite_articles": "https://infinite.tcgplayer.com/search?contentMode=article&game=magic&partner=scryfall&q=Shock&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "tcgplayer_infinite_decks": "https://infinite.tcgplayer.com/search?contentMode=deck&game=magic&partner=scryfall&q=Shock&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "edhrec": "https://edhrec.com/route/?cc=Shock"
+    },
+    "purchase_uris": {
+      "tcgplayer": "https://www.tcgplayer.com/product/126437?page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
+      "cardmarket": "https://www.cardmarket.com/en/Magic/Products/Search?referrer=scryfall&searchString=Shock&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+      "cardhoarder": "https://www.cardhoarder.com/cards/62923?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+    }
+  }
+]


### PR DESCRIPTION
Add scryfall parsing to mtgo parser (parses the format that mtgogetter outputs after filtering from the scryfall API).

Changes made to the mtgogetter to filter out cards that do not exist on MTGO.

Also adds more test data