### PR TITLE
Copy keep full trade list

### DIFF
--- a/mtgogui/Cargo.lock
+++ b/mtgogui/Cargo.lock
@@ -73,7 +73,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -426,6 +429,7 @@ dependencies = [
 name = "mtgogui"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "flexi_logger",
  "fltk",
  "fltk-flex",
@@ -435,6 +439,10 @@ dependencies = [
  "log",
  "mtgoupdater",
  "pretty_assertions",
+ "serde",
+ "serde_derive",
+ "temp-dir",
+ "toml",
  "url",
 ]
 
@@ -655,6 +663,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "thiserror"

--- a/mtgogui/Cargo.toml
+++ b/mtgogui/Cargo.toml
@@ -19,9 +19,14 @@ mtgoupdater = { version = "0.1.0", path = "../mtgoupdater"}
 url = "2.4.1"
 flexi_logger = { version = "0.27", features = ["async", "specfile"] }
 log = "0.4"
+serde = "1.0.190"
+toml = "0.8.6"
+serde_derive = "1.0.190"
+chrono =  { version = "0.4.31", features = ["serde"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+temp-dir = "0.1.11"
 
 
 [profile.release]

--- a/mtgogui/src/appdata.rs
+++ b/mtgogui/src/appdata.rs
@@ -1,5 +1,6 @@
 pub mod paths;
 pub mod update;
+pub mod util;
 
 // Directory that stores all collection data
 pub const APP_DATA_DIR: &str = "appdata";

--- a/mtgogui/src/appdata.rs
+++ b/mtgogui/src/appdata.rs
@@ -2,5 +2,7 @@ pub mod paths;
 pub mod update;
 pub mod util;
 
-// Directory that stores all collection data
+/// Directory that stores all collection data
 pub const APP_DATA_DIR: &str = "appdata";
+/// Name of the file that stores the current full trade list in the appdata directory
+pub const CURRENT_FULL_TRADE_LIST: &str = "current-full-trade-list.dek";

--- a/mtgogui/src/appdata.rs
+++ b/mtgogui/src/appdata.rs
@@ -1,4 +1,5 @@
 pub mod paths;
+pub mod state;
 pub mod update;
 pub mod util;
 
@@ -6,3 +7,5 @@ pub mod util;
 pub const APP_DATA_DIR: &str = "appdata";
 /// Name of the file that stores the current full trade list in the appdata directory
 pub const CURRENT_FULL_TRADE_LIST: &str = "current-full-trade-list.dek";
+/// Name of the file that stores state information for the GUI
+pub const GUI_STATE: &str = "gui-state.toml";

--- a/mtgogui/src/appdata/state.rs
+++ b/mtgogui/src/appdata/state.rs
@@ -1,0 +1,104 @@
+use std::{ffi::OsString, io, path::PathBuf};
+
+use chrono::prelude::*;
+use serde_derive::{Deserialize, Serialize};
+use toml::Table;
+
+use super::GUI_STATE;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+pub struct GuiState {
+    tradelist_added_date: DateTime<Utc>,
+}
+
+impl GuiState {
+    /// Create a new [GuiState] instance
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Save the [GuiState] to the given directory as a TOML file.
+    ///
+    /// # Arguments
+    ///
+    /// * `dst_dir` - The directory to save the [GuiState] to.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [io::Error] if the [GuiState] fails to be saved.
+    pub fn save(&self, mut dst_dir: PathBuf) -> io::Result<()> {
+        dst_dir.push(GUI_STATE);
+        let toml = toml::to_string(&self).expect("Failed to serialize GUI state");
+        std::fs::write(dst_dir, toml)?;
+        Ok(())
+    }
+
+    /// Load the [GuiState] from the given directory containing a TOML file named [GUI_STATE].
+    ///
+    /// # Arguments
+    ///
+    /// * `src_dir` - The directory to load the [GuiState] from.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [io::Error] if the [GuiState] fails to be loaded.
+    pub fn load(mut src_dir: PathBuf) -> io::Result<Self> {
+        src_dir.push(GUI_STATE);
+        let toml = std::fs::read_to_string(src_dir)?;
+        let gui_state: GuiState = toml::from_str(&toml).expect("Failed to deserialize GUI state");
+        Ok(gui_state)
+    }
+
+    /// Assign the current date and time to the [GuiState] tradelist_added_date field.
+    pub fn new_tradelist(&mut self) {
+        self.tradelist_added_date = Utc::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use temp_dir::TempDir;
+
+    #[test]
+    fn test_gui_state_load_save() {
+        let tmpdir = TempDir::new().unwrap();
+        let tmpdir_path = tmpdir.path().to_path_buf();
+
+        let gui_state = GuiState::new();
+
+        gui_state.save(tmpdir_path.clone()).unwrap();
+        let gui_state_loaded = GuiState::load(tmpdir_path).unwrap();
+
+        assert_eq!(gui_state, gui_state_loaded);
+    }
+
+    #[test]
+    fn test_gui_state_tradelist_data() {
+        let mut gui_state = GuiState::new();
+        let now = Utc::now();
+        gui_state.tradelist_added_date = now;
+
+        let after = now + chrono::Duration::seconds(1);
+
+        assert!(gui_state.tradelist_added_date < after);
+    }
+
+    #[test]
+    fn test_gui_state_tradelist_data_serde() {
+        let tmpdir = TempDir::new().unwrap();
+        let tmpdir_path = tmpdir.path().to_path_buf();
+
+        let mut gui_state = GuiState::new();
+        let now = Utc::now();
+        gui_state.tradelist_added_date = now;
+
+        gui_state.save(tmpdir_path.clone()).unwrap();
+        let gui_state_loaded = GuiState::load(tmpdir_path).unwrap();
+
+        assert_eq!(gui_state, gui_state_loaded);
+        assert_eq!(gui_state_loaded.tradelist_added_date, now);
+        assert!(gui_state_loaded.tradelist_added_date < now + chrono::Duration::seconds(1));
+    }
+}

--- a/mtgogui/src/appdata/state.rs
+++ b/mtgogui/src/appdata/state.rs
@@ -33,7 +33,7 @@ impl GuiState {
         Ok(())
     }
 
-    /// Load the [GuiState] from the given directory containing a TOML file named [GUI_STATE].
+    /// Load the [GuiState] from the given directory containing a TOML file named [GUI_STATE] or create a default [GuiState] if there's no matching file in the directory.
     ///
     /// # Arguments
     ///
@@ -44,14 +44,24 @@ impl GuiState {
     /// Returns an [io::Error] if the [GuiState] fails to be loaded.
     pub fn load(mut src_dir: PathBuf) -> io::Result<Self> {
         src_dir.push(GUI_STATE);
-        let toml = std::fs::read_to_string(src_dir)?;
-        let gui_state: GuiState = toml::from_str(&toml).expect("Failed to deserialize GUI state");
+        let gui_state = if src_dir.exists() {
+            let toml = std::fs::read_to_string(src_dir)?;
+            toml::from_str(&toml).expect("Failed to deserialize GUI state")
+        } else {
+            log::info!("No GUI state found, creating default GUI state");
+            Self::new()
+        };
         Ok(gui_state)
     }
 
-    /// Assign the current date and time to the [GuiState] tradelist_added_date field.
+    /// Save the current [DateTime<Utc>] as the last time a tradelist was added.
     pub fn new_tradelist(&mut self) {
         self.tradelist_added_date = Utc::now();
+    }
+
+    /// Get the [DateTime<Utc>] of the last time a tradelist was added.
+    pub fn get_tradelist_added_date(&self) -> DateTime<Utc> {
+        self.tradelist_added_date
     }
 }
 

--- a/mtgogui/src/appdata/update.rs
+++ b/mtgogui/src/appdata/update.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::util::first_file_match_from_dir;
+use crate::util::{self, first_file_match_from_dir};
 
 use super::{paths::CardDataPaths, APP_DATA_DIR};
 
@@ -22,24 +22,7 @@ impl AppData {
     ///
     /// Fails if not all the expected files can be located or the MTGO Getter fails to update the data
     pub fn update() -> Result<Self, Error> {
-        let mut appdata_dir =
-            std::env::current_exe().expect("Failed to get current executable path");
-        log::info!("Path to executable: {appdata_dir:?}");
-        appdata_dir.pop();
-        if cfg!(windows) {
-            appdata_dir.push(format!(r#"{APP_DATA_DIR}\"#));
-        } else {
-            appdata_dir.push(format!(r#"{APP_DATA_DIR}/"#));
-        }
-        log::info!("Path to appdata dir: {appdata_dir:?}");
-
-        if !appdata_dir.exists() {
-            log::info!("App data path doesn't exist! - {appdata_dir:?}");
-            return Err(Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("App data path {APP_DATA_DIR} doesn't exist!"),
-            ));
-        }
+        let appdata_dir = super::util::appdata_path()?;
 
         // Get App Data
         match mtgoupdater::mtgogetter_api::mtgogetter_update_all(appdata_dir.as_os_str()) {

--- a/mtgogui/src/appdata/util.rs
+++ b/mtgogui/src/appdata/util.rs
@@ -1,4 +1,5 @@
-use super::APP_DATA_DIR;
+use super::{APP_DATA_DIR, CURRENT_FULL_TRADE_LIST};
+use std::ffi::OsStr;
 use std::io;
 use std::path::PathBuf;
 
@@ -28,4 +29,37 @@ pub fn appdata_path() -> io::Result<PathBuf> {
     }
 
     Ok(appdata_dir)
+}
+
+/// Copy the given full trade list to the appdata directory
+///
+/// # Arguments
+///
+/// * `full_trade_list_path` - [OsStr] path to the full trade list
+///
+/// # Errors
+///
+/// * If the full trade list cannot be copied to the appdata directory
+pub fn copy_tradelist_to_appdata(full_trade_list_path: &OsStr) -> io::Result<()> {
+    let mut appdata_dir = crate::appdata::util::appdata_path()?;
+    appdata_dir.push(CURRENT_FULL_TRADE_LIST);
+    std::fs::copy(full_trade_list_path, &appdata_dir)?;
+    Ok(())
+}
+
+/// Get the path to the current full trade list in the appdata directory if it exists.
+/// Returns [None] if the file doesn't exist.
+///
+/// # Errors
+///
+/// * If the path to the appdata directory cannot be determined
+pub fn current_tradelist_path() -> io::Result<Option<PathBuf>> {
+    let mut appdata_dir = crate::appdata::util::appdata_path()?;
+    appdata_dir.push(CURRENT_FULL_TRADE_LIST);
+    if appdata_dir.exists() && appdata_dir.is_file() {
+        Ok(Some(appdata_dir))
+    } else {
+        log::info!("Current full trade list doesn't exist at: {appdata_dir:?}");
+        Ok(None)
+    }
 }

--- a/mtgogui/src/appdata/util.rs
+++ b/mtgogui/src/appdata/util.rs
@@ -1,0 +1,31 @@
+use super::APP_DATA_DIR;
+use std::io;
+use std::path::PathBuf;
+
+/// Get the path to the appdata directory
+///
+/// # Errors
+///
+/// * If the path to the appdata directory cannot be determined
+/// * If the path to the appdata directory doesn't exist
+pub fn appdata_path() -> io::Result<PathBuf> {
+    let mut appdata_dir = std::env::current_exe()?;
+    log::info!("Path to executable: {appdata_dir:?}");
+    appdata_dir.pop();
+    if cfg!(windows) {
+        appdata_dir.push(format!(r#"{APP_DATA_DIR}\"#));
+    } else {
+        appdata_dir.push(format!(r#"{APP_DATA_DIR}/"#));
+    }
+    log::info!("Path to appdata dir: {appdata_dir:?}");
+
+    if !appdata_dir.exists() {
+        log::info!("App data path doesn't exist! - {appdata_dir:?}");
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("App data path {APP_DATA_DIR} doesn't exist!"),
+        ));
+    }
+
+    Ok(appdata_dir)
+}

--- a/mtgogui/src/gui.rs
+++ b/mtgogui/src/gui.rs
@@ -33,7 +33,6 @@ mod setup;
 /// [MtgoGui] is the main GUI struct that holds all the widgets and state for the application
 pub struct MtgoGui {
     app: app::App,
-    full_tradelist: Option<PathBuf>,
     rcv: app::Receiver<Message>,
     main_win: window::Window,
     menu: McmMenuBar,
@@ -77,7 +76,6 @@ impl MtgoGui {
         });
         Self {
             app,
-            full_tradelist: None,
             rcv: ev_rcv,
             main_win,
             menu,
@@ -92,7 +90,7 @@ impl MtgoGui {
     fn run_startup(&mut self) {
         match appdata::util::current_tradelist_path() {
             Ok(Some(current_trade_list)) => {
-                self.full_tradelist = Some(current_trade_list);
+                self.tradelist_processor.process(current_trade_list.into())
             }
             Err(e) => {
                 // TODO - Error pop-up dialog if fails.

--- a/mtgogui/src/gui/setup.rs
+++ b/mtgogui/src/gui/setup.rs
@@ -1,8 +1,9 @@
 use fltk::{
     app, button,
-    enums::{self, CallbackTrigger, Color},
+    enums::{self, Align, CallbackTrigger, Color},
     frame, input,
-    prelude::{GroupExt, ImageExt, InputExt, WidgetBase, WidgetExt, WindowExt},
+    prelude::{DisplayExt, GroupExt, ImageExt, InputExt, WidgetBase, WidgetExt, WindowExt},
+    text::{TextBuffer, TextDisplay, WrapMode},
     window::{DoubleWindow, Window},
 };
 use fltk_flex::Flex;
@@ -19,7 +20,7 @@ use crate::{
 /// # Arguments
 ///
 /// * `ev_send` - Sender to send messages to the main thread
-pub(super) fn set_left_col_box(ev_send: app::Sender<Message>) {
+pub(super) fn set_left_col_box(ev_send: app::Sender<Message>) -> TextDisplay {
     let mut search_box_grid_row = Grid::new(0, 0, 400, 30, "");
     if cfg!(debug_assertions) {
         // Show box edges and coordinates
@@ -40,8 +41,17 @@ pub(super) fn set_left_col_box(ev_send: app::Sender<Message>) {
             s.send(TableMessage::Search(i.value().into()).into());
         }
     });
+
     search_box_grid_row.set_widget(&mut frame, 0, 0);
     search_box_grid_row.set_widget(&mut search_input, 0, 1..4);
+
+    let mut frame_tradelist_age = frame::Frame::new(0, 0, 0, 10, "Tradelist set:");
+    let mut txt_disp_tradelist_age = TextDisplay::default();
+    txt_disp_tradelist_age.set_align(Align::Center | Align::Inside);
+    txt_disp_tradelist_age.wrap_mode(WrapMode::AtBounds, 0);
+
+    search_box_grid_row.set_widget(&mut frame_tradelist_age, 1, 0);
+    search_box_grid_row.set_widget(&mut txt_disp_tradelist_age, 1, 1..4);
 
     search_box_grid_row.end();
 
@@ -55,6 +65,7 @@ pub(super) fn set_left_col_box(ev_send: app::Sender<Message>) {
             }
         });
     }
+    txt_disp_tradelist_age
 }
 
 /// Sets up the main window of the application


### PR DESCRIPTION
resolves #70 

- [x] Copies a given tradelist to the appdata directory
- [x] Checks at startup if a tradelist is in the appdata directory, if it is, process and displays data for that tradelist
- [x] Saves a timestamp (needs a local config/state file to load/store this kind of state)
- [x] Displays the date at which the current tradelist was set
