### PR TITLE
Save card price history

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -36,6 +36,11 @@ jobs:
             generator: "Ninja Multi-Config"
             enable_ipo: Off
 
+          - os: macos-13
+            compiler: gcc-13
+            generator: "Ninja Multi-Config"
+            enable_ipo: Off
+
           - os: windows-2022
             compiler: msvc
             generator: "Visual Studio 17 2022"

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -97,7 +97,7 @@ namespace fs = std::filesystem;
     std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
 
     // Convert to a tm struct in UTC (std::gmtime converts to UTC) and %Y-%m-%dT%H-%M-%SZ is ISO 8601
-    const auto now_utc_iso8601 = std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H-%M-%SZ");
+    const auto now_utc_iso8601 = std::put_time(std::gmtime_s(&now_time_t), "%Y-%m-%dT%H-%M-%SZ");
 
     // Convert the tm struct to a string
     std::ostringstream ss;

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -100,9 +100,18 @@ namespace fs = std::filesystem;
     // Get the current time
     const auto now = std::chrono::system_clock::now();
 
+
     // Convert to a timestamp in UTC and %Y-%m-%dT%H:%M:%SZ which is ISO 8601
     // using formatter: https://en.cppreference.com/w/cpp/chrono/system_clock/formatter
+
+    // Apple clang is behind on C++20 support, so std::format is not consteval yet, meaning we can use it as is for
+    // runtime formatting.
+#if defined(__APPLE__) && defined(__llvm__) && __clang_major__ == 15
+    std::string tmp_iso8601_timestamp = std::format("{:%FT%TZ}", now);
+#else
+    // std::vformat is the way to specify a runtime format string in C++20
     std::string tmp_iso8601_timestamp = std::vformat("{:%FT%TZ}", std::make_format_args(now));
+#endif
 
     // It has sub-second precision, so remove the decimal point and everything after it, then add a 'Z' to indicate UTC
     std::string now_utc_iso8601_timestamp = tmp_iso8601_timestamp.substr(0, tmp_iso8601_timestamp.find('.')) + 'Z';

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -104,21 +104,24 @@ namespace fs = std::filesystem;
     // Convert to a timestamp in UTC and %Y-%m-%dT%H:%M:%SZ which is ISO 8601
     // using formatter: https://en.cppreference.com/w/cpp/chrono/system_clock/formatter
 
-    // Apple clang is behind on C++20 support, so std::format is not consteval yet, meaning we can use it as is for
-    // runtime formatting.
+    // Apple clang is behind on C++20 support, so use std::put_time instead of std::format
 #if defined(__APPLE__) && defined(__llvm__) && __clang_major__ == 15
-    std::string tmp_iso8601_timestamp = std::format("{:%FT%TZ}", now);
+    auto now_time_t = std::chrono::system_clock::to_time_t(now);
+
+    // Convert to ISO 8601 format
+    std::ostringstream oss;
+    oss << std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H%M%SZ");
+    std::string now_utc_iso8601_timestamp = oss.str();
 #else
     // std::vformat is the way to specify a runtime format string in C++20
     std::string tmp_iso8601_timestamp = std::vformat("{:%FT%TZ}", std::make_format_args(now));
-#endif
-
     // It has sub-second precision, so remove the decimal point and everything after it, then add a 'Z' to indicate UTC
     std::string now_utc_iso8601_timestamp = tmp_iso8601_timestamp.substr(0, tmp_iso8601_timestamp.find('.')) + 'Z';
     // Erase-remove idiom to remove colons from timestamp as they are not allowed in Windows file names
     now_utc_iso8601_timestamp.erase(
       std::remove(now_utc_iso8601_timestamp.begin(), now_utc_iso8601_timestamp.end(), ':'),
       now_utc_iso8601_timestamp.end());
+#endif
 
     std::string final_fname = fmt::format("{}_{}.{}", fpath.stem().string(), now_utc_iso8601_timestamp, ext);
 

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -4,6 +4,11 @@
 #include <toml++/toml.hpp>
 // NOLINTEND
 
+#include <boost/outcome.hpp>
+#include <boost/outcome/result.hpp>
+
+#include <fmt/core.h>
+
 #include <filesystem>
 #include <fstream>
 #include <ios>
@@ -12,13 +17,16 @@
 
 namespace io_util {
 
-[[nodiscard]] inline auto read_to_str_buf(const std::filesystem::path &fpath) -> std::string
+namespace outcome = BOOST_OUTCOME_V2_NAMESPACE;
+namespace fs = std::filesystem;
+
+[[nodiscard]] inline auto read_to_str_buf(const fs::path &fpath) -> std::string
 {
   // Open the stream to 'lock' the file.
   std::ifstream file(fpath, std::ios::in | std::ios::binary);
 
   // Obtain the size of the file.
-  const auto fsize = std::filesystem::file_size(fpath);
+  const auto fsize = fs::file_size(fpath);
 
   // Create a buffer.
   std::string str_buffer(fsize, '\0');
@@ -29,13 +37,13 @@ namespace io_util {
   return str_buffer;
 }
 
-[[nodiscard]] inline auto read_to_char_buf(const std::filesystem::path &fpath) -> std::vector<char>
+[[nodiscard]] inline auto read_to_char_buf(const fs::path &fpath) -> std::vector<char>
 {
   // Open the stream to 'lock' the file.
   std::ifstream file(fpath, std::ios::in | std::ios::binary);
 
   // Obtain the size of the file.
-  const auto fsize = std::filesystem::file_size(fpath);
+  const auto fsize = fs::file_size(fpath);
 
   // Instantiate and pre-allocate
   std::vector<char> char_buf{};
@@ -50,9 +58,66 @@ namespace io_util {
   return char_buf;
 }
 
+/**
+ * @brief Read a TOML file into a TOML table.
+ *
+ * @param str_fpath The path to the TOML file
+ * @return decltype(auto) The TOML table
+ */
 [[nodiscard]] inline auto read_state_log(const std::string_view str_fpath) -> decltype(auto)
 {
   return toml::parse_file(str_fpath);
+}
+
+/**
+ * @brief Save a string buffer to a file with an ISO 8601 timestamp appended to the file name.
+ *
+ * Any directories in the path that do not exist will be created.
+ *
+ * @param buf The string buffer to save
+ *
+ * @param fpath The path to the file to save to
+ *
+ * @param ext The file extension to append to the file name
+ *
+ * @return On success: The path to the saved file
+ * @return On failure: The error message
+ */
+[[nodiscard]] inline auto save_with_timestamp(auto buf, const fs::path &fpath, auto ext)
+  -> outcome::result<fs::path, std::string>
+{
+  try {
+    // If the path is not to the current directory
+    if (fpath.has_parent_path()) {
+      // Create directories if they don't exist
+      fs::create_directories(fpath.parent_path());
+    }
+    // Get the current time
+    auto now = std::chrono::system_clock::now();
+    std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
+
+    // Convert to a tm struct in UTC (std::gmtime converts to UTC) and %Y-%m-%dT%H-%M-%SZ is ISO 8601
+    const auto now_utc_iso8601 = std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H-%M-%SZ");
+
+    // Convert the tm struct to a string
+    std::ostringstream ss;
+    ss << now_utc_iso8601;
+    std::string timestamp = ss.str();
+
+    fs::path fpath_with_time = fpath.parent_path() / fmt::format("{}_{}.{}", fpath.stem().string(), timestamp, ext);
+
+    // Open the file
+    std::ofstream file(fpath_with_time, std::ios::out | std::ios::binary);
+
+    // Write the buffer to the file
+    file.write(buf.data(), static_cast<std::streamsize>(buf.size()));
+
+    // Return the file name
+    return outcome::success(fpath_with_time);
+
+  } catch (const std::exception &e) {
+    return outcome::failure(fmt::format("Failed to save file from path: {}, err: {}", fpath.string(), e.what()));
+  }
 }
 
 }// namespace io_util

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -4,6 +4,7 @@
 #include <toml++/toml.hpp>
 // NOLINTEND
 
+#include <boost/implicit_cast.hpp>
 #include <boost/outcome.hpp>
 #include <boost/outcome/result.hpp>
 
@@ -112,7 +113,8 @@ namespace fs = std::filesystem;
 
     std::string final_fname = fmt::format("{}_{}.{}", fpath.stem().string(), now_utc_iso8601_timestamp, ext);
 
-    fs::path fpath_with_time = fpath.has_parent_path() ? fpath.parent_path() / final_fname : final_fname;
+    fs::path fpath_with_time =
+      fpath.has_parent_path() ? fpath.parent_path() / final_fname : boost::implicit_cast<fs::path>(final_fname);
 
     // Open the file
     std::ofstream file(fpath_with_time, std::ios::binary | std::ios::out);

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -102,7 +102,7 @@ namespace fs = std::filesystem;
 
     // Convert to a timestamp in UTC and %Y-%m-%dT%H:%M:%SZ which is ISO 8601
     // using formatter: https://en.cppreference.com/w/cpp/chrono/system_clock/formatter
-    std::string tmp_iso8601_timestamp = std::format("{:%FT%TZ}", now);
+    std::string tmp_iso8601_timestamp = std::vformat("{:%FT%TZ}", std::make_format_args(now));
 
     // It has sub-second precision, so remove the decimal point and everything after it, then add a 'Z' to indicate UTC
     std::string now_utc_iso8601_timestamp = tmp_iso8601_timestamp.substr(0, tmp_iso8601_timestamp.find('.')) + 'Z';

--- a/mtgoparser/src/mtgo_preprocessor/run.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/run.cpp
@@ -104,8 +104,8 @@ namespace helper {
   [[nodiscard]] auto check_goatbots_path_args() -> outcome::result<Success, ErrorStr>
   {
     // First check if the arguments are set
-    bool arg_set_card_defs_path = cfg::get()->FlagSet(config::option::card_defs_path);
-    bool arg_set_price_hist_path = cfg::get()->FlagSet(config::option::price_hist_path);
+    const bool arg_set_card_defs_path = cfg::get()->FlagSet(config::option::card_defs_path);
+    const bool arg_set_price_hist_path = cfg::get()->FlagSet(config::option::price_hist_path);
 
     if (!arg_set_card_defs_path && !arg_set_price_hist_path) {
       return outcome::failure("Card definitions and price history path options not provided");
@@ -116,8 +116,8 @@ namespace helper {
     if (!arg_set_price_hist_path) { return outcome::failure("Price history path option not provided"); }
 
     // Check if they have values
-    auto card_defs_path = cfg::get()->OptionValue(config::option::card_defs_path);
-    auto price_hist_path = cfg::get()->OptionValue(config::option::price_hist_path);
+    const auto card_defs_path = cfg::get()->OptionValue(config::option::card_defs_path);
+    const auto price_hist_path = cfg::get()->OptionValue(config::option::price_hist_path);
 
     if (!card_defs_path.has_value() && !price_hist_path.has_value()) {
       return outcome::failure("Missing card definitions and price history path from arguments");

--- a/mtgoparser/src/mtgo_preprocessor/run.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/run.cpp
@@ -69,7 +69,10 @@ namespace helper {
   {
     const std::string fname{ "mtgo-cards" };
     const std::string ext{ ".json" };
-    const std::filesystem::path save_path = std::string(jsonAndDir.dir) + "/collection-history/" + fname;
+    std::filesystem::path save_path = jsonAndDir.dir;
+    save_path.append("collection-history");
+    save_path.append(fname);
+
     spdlog::info("Saving preprocessed JSON to {}", save_path.string());
 
     // Check if the state_log in the appdata has changed
@@ -84,6 +87,10 @@ namespace helper {
 
       std::filesystem::path log_fullpath_collection_history = jsonAndDir.dir;
       log_fullpath_collection_history.append("collection-history");
+      // If the collection-history directory does not exist, create it
+      if (!std::filesystem::exists(log_fullpath_collection_history)) {
+        std::filesystem::create_directory(log_fullpath_collection_history);
+      }
       log_fullpath_collection_history.append(state_log);
 
       std::filesystem::copy_file(


### PR DESCRIPTION
resolves #71 

- [x] Save preprocessed json to `collection-history` subdirectory of the `appdata` directory
- [x] Only save preprocessed json if it is not identical to the previously saved json (avoid duplicate stores)
Proposal: Copy state_log.toml to the `collection-history` directory and compare the current state_log to the stored one to see if the json needs to be stored
 
## Make new issue with these tasks ✔️ 
https://github.com/CramBL/mtgo-collection-manager/issues/81
>- Functionality for the preprocessor to aggregate all the history data into a single json file and write it to stdout
>- MTGO GUI receives this and does something meaningful with it