### PR TITLE
Small improvements to MTGO Parser

### DIFF
--- a/mtgoparser/include/mtgo_preprocessor/run.hpp
+++ b/mtgoparser/include/mtgo_preprocessor/run.hpp
@@ -47,7 +47,7 @@ using ErrorStr = std::string;
  *
  * @note The paths are specified as `std::string_view` to avoid copying the strings.
  */
-struct GoatbotsPaths
+struct [[nodiscard]] GoatbotsPaths
 {
   std::string_view card_defs_path;
   std::string_view price_hist_path;

--- a/mtgoparser/include/mtgoparser/clap/command.hpp
+++ b/mtgoparser/include/mtgoparser/clap/command.hpp
@@ -18,7 +18,7 @@ namespace clap {
  *
  * @example `constexpr auto my_cmd = clap::Command{ "help", false }`
  */
-struct Command
+struct [[nodiscard]] Command
 {
   std::string_view name_;
   bool is_flag_;

--- a/mtgoparser/include/mtgoparser/clap/option.hpp
+++ b/mtgoparser/include/mtgoparser/clap/option.hpp
@@ -26,7 +26,7 @@ static inline constexpr size_t MAX_ALIAS_COUNT = 3;
  * @note `Flag` is for options that toggle a boolean value.
  * @note `NeedValue` is for options that require a value.
  */
-enum class Opt : uint8_t { Flag, NeedValue };
+enum class [[nodiscard]] Opt : uint8_t { Flag, NeedValue };
 
 
 /**
@@ -34,7 +34,7 @@ enum class Opt : uint8_t { Flag, NeedValue };
  *
  * @example `constexpr auto my_opt = clap::Option{ "help", clap::Opt::Flag, "h", "help", "H" }`
  */
-struct Option
+struct [[nodiscard]] Option
 {
   using T_opt_sv = std::optional<std::string_view>;
   using T_alias_array = std::array<T_opt_sv, clap::MAX_ALIAS_COUNT>;

--- a/mtgoparser/include/mtgoparser/clap/util.hpp
+++ b/mtgoparser/include/mtgoparser/clap/util.hpp
@@ -33,7 +33,7 @@ template<typename T, typename... Args>
  *
  * @tparam T
  */
-template<typename T> struct is_convertible_to_string_view
+template<typename T> struct [[nodiscard]] is_convertible_to_string_view
 {
   static constexpr bool value = std::is_convertible_v<T, std::string_view>;
 };

--- a/mtgoparser/include/mtgoparser/goatbots.hpp
+++ b/mtgoparser/include/mtgoparser/goatbots.hpp
@@ -53,7 +53,7 @@ template<goatbots_json T>
   json_map.reserve(RESERVE_APPROX_CARD_COUNT);
 
   // Read file into buffer and decode to populate map
-  if (auto err_code = glz::read_json(json_map, io_util::read_to_str_buf(path_json))) {
+  if (auto err_code = glz::read_json(json_map, io_util::read_to_str_buf(path_json))) [[unlikely]] {
     return outcome::failure(fmt::format(
       "Reading JSON from {} failed with {}", path_json.string(), glz::format_error(err_code, std::string{})));
   }

--- a/mtgoparser/include/mtgoparser/goatbots.hpp
+++ b/mtgoparser/include/mtgoparser/goatbots.hpp
@@ -25,7 +25,7 @@ using ErrorStr = std::string;
 // Try to only allocate once, so reserve more than card count
 const uint32_t RESERVE_APPROX_CARD_COUNT = 80000;
 
-struct CardDefinition
+struct [[nodiscard]] CardDefinition
 {
   std::string name{};
   std::string cardset{};

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -151,7 +151,7 @@ using ErrorStr = std::string;
     // Open the file
     std::ofstream file(fpath_with_time, std::ios::binary | std::ios::out);
 
-    if (file.bad()) {
+    if (file.bad()) [[unlikely]] {
       return outcome::failure(fmt::format("Bad operation during opening of file: {}", fpath_with_time.string()));
     }
 
@@ -160,7 +160,7 @@ using ErrorStr = std::string;
       file.write(buf.data(), static_cast<std::streamsize>(buf.size()));
       // Close the file
       file.close();
-    } else {
+    } else [[unlikely]] {
       return outcome::failure(fmt::format("Expected file to be open: {}", fpath_with_time.string()));
     }
 
@@ -192,7 +192,7 @@ using ErrorStr = std::string;
   std::ifstream fB(fpathB, std::ifstream::binary | std::ifstream::ate);
 
   // If there was a problem opening the files
-  if (fA.fail() || fB.fail()) {
+  if (fA.fail() || fB.fail()) [[unlikely]] {
     std::string error_msg = "Error encountered opening and seeking to end of: ";
     if (fA.fail() && fB.fail()) {
       error_msg += fmt::format("{} and {}", fpathA.string(), fpathB.string());

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -13,7 +13,7 @@
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -89,8 +89,6 @@ public:
 
   void PrettyPrint() const;
 
-  void FromJson(const std::string &json_str);
-
   [[nodiscard]] inline constexpr bool operator==(const Collection &other) const { return this->cards_ == other.cards_; }
   [[nodiscard]] inline constexpr bool operator!=(const Collection &other) const { return !(*this == other); }
 
@@ -172,13 +170,6 @@ void inline Collection::ExtractScryfallInfo(std::vector<scryfall::Card> &&scryfa
   return res;
 }
 
-
-void inline Collection::FromJson(const std::string &json_str)
-{
-  if (auto err_code = glz::read_json<std::vector<Card>>(std::ref(cards_), json_str)) {
-    spdlog::error("{}", glz::format_error(err_code, std::string{}));
-  }
-}
 void inline Collection::Print() const
 {
   for (const auto &card : cards_) {

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -106,7 +106,7 @@ void inline Collection::ExtractGoatbotsInfo(const goatbots::card_defs_map_t &car
 {
 
   for (auto &card : this->cards_) {
-    if (card.id_ == 1) {
+    if (card.id_ == 1) [[unlikely]] {
       // Event Tickets have value 1 per definition
       card.goatbots_price_ = 1.0;
       continue;
@@ -116,13 +116,13 @@ void inline Collection::ExtractGoatbotsInfo(const goatbots::card_defs_map_t &car
       card.set_ = res->second.cardset;
       card.rarity_ = mtg::util::rarity_from_t(res->second.rarity);
       card.foil_ = res->second.foil == 1;
-    } else {
+    } else [[unlikely]] {
       spdlog::warn("Card definition key not found: ID={}", card.id_);
     }
     // Extract price from goatbots price history
     if (auto res = price_hist.find(card.id_); res != price_hist.end()) {
       card.goatbots_price_ = res->second;
-    } else {
+    } else [[unlikely]] {
       spdlog::warn("Price history key not found: ID={}", card.id_);
     }
   }
@@ -148,7 +148,7 @@ void inline Collection::ExtractScryfallInfo(std::vector<scryfall::Card> &&scryfa
   for (auto &c : cards_) {
     // Skip if it is foil as scryfall API doesn't have foil prices
     if (c.foil_) { continue; }
-    if (c.id_ == 1) {
+    if (c.id_ == 1) [[unlikely]] {
       // Event ticket
       c.scryfall_price_ = 1.0;
       continue;

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -15,7 +15,7 @@
 
 namespace mtgo {
 
-struct Card
+struct [[nodiscard]] Card
 {
   uint32_t id_;
   uint16_t quantity_;
@@ -71,7 +71,7 @@ struct Card
 
   // Templated constructor
   template<typename I, typename Q, typename S>
-  requires std::convertible_to<I, uint32_t> && std::convertible_to<Q, uint16_t> && std::convertible_to<S, std::string>
+    requires std::convertible_to<I, uint32_t> && std::convertible_to<Q, uint16_t> && std::convertible_to<S, std::string>
   explicit Card(I id,
     Q quantity,
     S name,

--- a/mtgoparser/include/mtgoparser/mtgo/xml.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/xml.hpp
@@ -34,28 +34,28 @@ using ErrorStr = std::string;
  */
 [[nodiscard]] inline auto card_from_xml(rapidxml::xml_node<> *card_node) noexcept -> outcome::result<Card, ErrorStr>
 {
-  if (card_node == nullptr) { return outcome::failure("card_node is null"); }
+  if (card_node == nullptr) [[unlikely]] { return outcome::failure("card_node is null"); }
 
   auto *first_attr = card_node->first_attribute();
   // 1st attribute (MTGO ID)
   auto res_attr_id = util::sv_to_uint<uint32_t>(first_attr->value());
-  if (res_attr_id.has_error()) { return outcome::failure(res_attr_id.error()); }
+  if (res_attr_id.has_error()) [[unlikely]] { return outcome::failure(res_attr_id.error()); }
 
   // 2nd attribute (quantity)
   auto *second_attr = first_attr->next_attribute();
-  if (second_attr == nullptr) { return outcome::failure("second_attr node (should be quantity) is null"); }
+  if (second_attr == nullptr) [[unlikely]] { return outcome::failure("second_attr node (should be quantity) is null"); }
 
   auto res_quantity = util::sv_to_uint<uint16_t>(second_attr->value());
-  if (res_quantity.has_error()) { return outcome::failure(res_quantity.error()); }
+  if (res_quantity.has_error()) [[unlikely]] { return outcome::failure(res_quantity.error()); }
 
 
   // 3rd attribute (Sideboard, we don't care about this but have to go through it)
   auto *third_attr = second_attr->next_attribute();
-  if (third_attr == nullptr) { return outcome::failure("third_attr node (should be sideboard) is null"); }
+  if (third_attr == nullptr) [[unlikely]] { return outcome::failure("third_attr node (should be sideboard) is null"); }
 
   // 4th attribute (name)
   auto *fourth_attr = third_attr->next_attribute();
-  if (fourth_attr == nullptr) { return outcome::failure("fourth_attr node (should be name) is null"); }
+  if (fourth_attr == nullptr) [[unlikely]] { return outcome::failure("fourth_attr node (should be name) is null"); }
   auto *name = fourth_attr->value();
   // 5th attribute (seems useless)
   // auto annotation = first_attr->next_attribute()->next_attribute()->next_attribute()->next_attribute()->value();
@@ -96,7 +96,7 @@ const std::size_t APPROX_DECK_CARDS = 1024;
     // Iterate through all attributes
     if (auto res_card_inst = card_from_xml(node); res_card_inst.has_value()) {
       cards.emplace_back(std::move(res_card_inst.value()));
-    } else {
+    } else [[unlikely]] {
       return outcome::failure(fmt::format("Decoding card from XML failed: {}", res_card_inst.error()));
     }
   }

--- a/mtgoparser/include/mtgoparser/scryfall.hpp
+++ b/mtgoparser/include/mtgoparser/scryfall.hpp
@@ -21,7 +21,7 @@ namespace scryfall {
  *
  * @note The prices are optional because not all cards have all prices.
  */
-struct Prices
+struct [[nodiscard]] Prices
 {
   using opt_str = std::optional<std::string>;
 
@@ -52,7 +52,7 @@ struct Prices
 /**
  * @brief A card as described by Scryfall data.
  */
-struct Card
+struct [[nodiscard]] Card
 {
   uint32_t mtgo_id{};
   std::string name{};
@@ -65,8 +65,8 @@ struct Card
     std::string _released_at = "",
     std::string _rarity = "",
     Prices _prices = scryfall::Prices{})
-    : mtgo_id{ _mtgo_id }, name{ std::move(_name) },
-      released_at{ std::move(_released_at) }, rarity{ std::move(_rarity) }, prices{ std::move(_prices) }
+    : mtgo_id{ _mtgo_id }, name{ std::move(_name) }, released_at{ std::move(_released_at) },
+      rarity{ std::move(_rarity) }, prices{ std::move(_prices) }
   {}
 
   [[nodiscard]] inline constexpr bool operator==(const Card &other) const

--- a/mtgoparser/include/mtgoparser/scryfall.hpp
+++ b/mtgoparser/include/mtgoparser/scryfall.hpp
@@ -127,7 +127,7 @@ using ErrorStr = std::string;
   scryfall_vec.reserve(RESERVE_APPROX_MAX_SCRYFALL_CARDS);
 
   // Read file into buffer and decode to populate map
-  if (auto err_code = glz::read_json(scryfall_vec, io_util::read_to_str_buf(path_json))) {
+  if (auto err_code = glz::read_json(scryfall_vec, io_util::read_to_str_buf(path_json))) [[unlikely]] {
     // Return error as a string
     return outcome::failure(glz::format_error(err_code, std::string{}));
   }

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -28,7 +28,7 @@ using ErrorStr = std::string;
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename SB>
-requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
+  requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
 [[nodiscard]] inline constexpr auto is_sv_same(SA a_sv, SB b_sv) -> bool
 {
   return boost::implicit_cast<std::string_view>(a_sv) == boost::implicit_cast<std::string_view>(b_sv);
@@ -51,8 +51,8 @@ requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, st
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename... Ss>
-requires std::convertible_to<SA, std::string_view> &&(std::convertible_to<Ss, std::string_view> || ...)
-  [[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
+  requires std::convertible_to<SA, std::string_view> && (std::convertible_to<Ss, std::string_view> || ...)
+[[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
 {
   return (is_sv_same(a_sv, bs_svs) || ...);
 }
@@ -76,9 +76,9 @@ template<typename T_uint> [[nodiscard]] inline auto sv_to_uint(std::string_view 
 {
   T_uint value{};
 
-  if (std::from_chars(sv.data(), sv.data() + sv.size(), value).ec == std::errc{}) {
+  if (std::from_chars(sv.data(), sv.data() + sv.size(), value).ec == std::errc{}) [[likely]] {
     return outcome::success(value);
-  } else {
+  } else [[unlikely]] {
     return outcome::failure(fmt::format("Failed to convert string_view `{}` to uint", sv));
   }
 }

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -28,7 +28,7 @@ using ErrorStr = std::string;
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename SB>
-  requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
+requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
 [[nodiscard]] inline constexpr auto is_sv_same(SA a_sv, SB b_sv) -> bool
 {
   return boost::implicit_cast<std::string_view>(a_sv) == boost::implicit_cast<std::string_view>(b_sv);
@@ -51,8 +51,8 @@ template<typename SA, typename SB>
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename... Ss>
-  requires std::convertible_to<SA, std::string_view> && (std::convertible_to<Ss, std::string_view> || ...)
-[[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
+requires std::convertible_to<SA, std::string_view> &&(std::convertible_to<Ss, std::string_view> || ...)
+  [[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
 {
   return (is_sv_same(a_sv, bs_svs) || ...);
 }

--- a/mtgoparser/src/mtgo_preprocessor/main.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/main.cpp
@@ -81,29 +81,30 @@ int main(int argc, char *argv[])
 
     std::vector<std::string_view> args{ argv + 1, argv + argc };
 
-    if (auto res = mtgo_preprocessor::setup::setup(args); res.has_error()) {
+    if (auto res = mtgo_preprocessor::setup::setup(args); res.has_error()) [[unlikely]] {
       spdlog::error("{}", res.error());
       return -1;
     }
 
 
-    if (cfg::get()->FlagSet(config::option::help)) {
+    if (cfg::get()->FlagSet(config::option::help)) [[unlikely]] {
       cfg::get()->PrintShortHelp();
       return 0;
     }
 
     if (cfg::get()->FlagSet(config::option::echo)) { cfg::get()->PrintArgs(); }
 
-    if (cfg::get()->FlagSet("--version")) {
+    if (cfg::get()->FlagSet("--version")) [[unlikely]] {
       fmt::println("v{}", mtgoparser::cmake::project_version);
       return 0;
     }
 
     if (cfg::get()->CmdSet(config::commands::run)) {
-      if (auto res = mtgo_preprocessor::run::run(); res.has_error()) {
+      if (auto res = mtgo_preprocessor::run::run(); res.has_error()) [[unlikely]] {
         spdlog::error("{}", res.error());
         return -1;
       }
+      return 0;
     }
 
     if (cfg::get()->FlagSet(config::option::debug) && cfg::get()->FlagSet(config::option::mtgoupdater_json_out)) {

--- a/mtgoparser/src/mtgo_preprocessor/run.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/run.cpp
@@ -58,7 +58,7 @@ namespace helper {
   }
 
 
-  struct JsonAndDestinationDir
+  struct [[nodiscard]] JsonAndDestinationDir
   {
     std::string_view json;
     std::string_view dir;

--- a/mtgoparser/src/mtgo_preprocessor/run.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/run.cpp
@@ -234,36 +234,35 @@ namespace helper {
   // Parse collection
 
   // Not possible if no full trade list path is supplied
-  if (!cfg::get()->FlagSet(config::option::fulltradelist_path)) {
+  if (!cfg::get()->FlagSet(config::option::fulltradelist_path)) [[unlikely]] {
     return outcome::failure("Update all needs a path to a full trade list XML file");
   }
 
   // Get cards from full trade list XML
   auto fulltradelist_path = cfg::get()->OptionValue(config::option::fulltradelist_path);
   assert(fulltradelist_path.has_value());
-  if (!fulltradelist_path.has_value()) {
+  if (!fulltradelist_path.has_value()) [[unlikely]] {
     return outcome::failure("Full Trade List path has no value. This error should be unreachable...");
   }
   auto res_mtgo_cards = mtgo::xml::parse_dek_xml(fulltradelist_path.value());
-  if (res_mtgo_cards.has_error()) { return outcome::failure(res_mtgo_cards.error()); }
+  if (res_mtgo_cards.has_error()) [[unlikely]] { return outcome::failure(res_mtgo_cards.error()); }
   auto mtgo_collection = mtgo::Collection(std::move(res_mtgo_cards.value()));
 
 
-  if (auto goatbots_path_args = helper::get_goatbots_path_args(); goatbots_path_args.has_error()) {
+  if (auto goatbots_path_args = helper::get_goatbots_path_args(); goatbots_path_args.has_error()) [[unlikely]] {
     return outcome::failure(goatbots_path_args.error());
-  } else {
-    if (auto res = parse_goatbots_data(mtgo_collection, goatbots_path_args.value()); res.has_error()) {
-
+  } else [[likely]] {
+    if (auto res = parse_goatbots_data(mtgo_collection, goatbots_path_args.value()); res.has_error()) [[unlikely]] {
       return outcome::failure(res.error());
     }
     spdlog::info("extract Goatbots info complete");
   }
 
 
-  if (!cfg::get()->FlagSet(config::option::scryfall_path)) {
+  if (!cfg::get()->FlagSet(config::option::scryfall_path)) [[unlikely]] {
     spdlog::error("Update all needs a path to a scryfall json-data file");
-  } else {
-    if (auto res = helper::parse_scryfall_data(mtgo_collection); res.has_error()) {
+  } else [[likely]] {
+    if (auto res = helper::parse_scryfall_data(mtgo_collection); res.has_error()) [[unlikely]] {
       return outcome::failure(res.error());
     }
     spdlog::info("extract Scryfall info completed");
@@ -277,7 +276,7 @@ namespace helper {
     // Write the json to a file in the appdata directory
     if (auto res =
           helper::write_json_to_appdata_dir(helper::JsonAndDestinationDir{ .json = json, .dir = appdata_dir.value() });
-        res.has_error()) {
+        res.has_error()) [[unlikely]] {
       spdlog::error("{}", res.error());// This is bad, but not fatal.
     }
   }
@@ -289,7 +288,7 @@ namespace helper {
 
 [[nodiscard]] auto run() -> outcome::result<Success, ErrorStr>
 {
-  if (cfg::get()->FlagSet(config::option::update)) { return update(); }
+  if (cfg::get()->FlagSet(config::option::update)) [[likely]] { return update(); }
   return outcome::success();
 }
 

--- a/mtgoparser/src/mtgo_preprocessor/setup.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/setup.cpp
@@ -22,9 +22,10 @@ namespace mtgo_preprocessor::setup {
   spdlog::set_default_logger(spdlog::stderr_color_st(""));
 
   // Parse (and validate) command-line arguments
-  if (auto errors = config::Config::get()->Parse(args)) {
+  if (auto errors = config::Config::get()->Parse(args)) [[unlikely]] {
     return fmt::format("{} argument(s) failed to validate", errors);
   };
+
   return outcome::success();
 }
 


### PR DESCRIPTION
- [x] Check branch prediction success rate with `perf` before/after
- [x] LLVM Comparison
- [x] GCC Comparison

## Conclusion

Simply marking the happy path `[[likely]]` and error branches `[[unlikely]]` resulted in 10% fewer missed branches on a full collection parse (which includes hitting a few unlikely branches e.g. special handling of MTGO ID == 1).

## Full parse of a collection of around 3k unique cards on an 8 year old ThinkPad (3rd gen) running Lubuntu 22.04.

### LLVM Before `73-85` ms
The branch misses were consistently above 310k. The range was approx. `310-325k` misses (~0.33%)
### LLVM After `70-73` ms
The branch misses are consistent below 310k in the same scenario as above. The range is now `300-310k` misses (~0.32%).

### GCC Before `65-70` ms
Approx. `330-350k` misses (~0.44%)

### GCC After `65-66` ms
Approx. `290-300k` misses (~0.40%)