### PR TITLE
CSV parsing for aggregated price history

### DIFF
--- a/mtgoparser/CMakeLists.txt
+++ b/mtgoparser/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 # Only set the cxx_standard if it is not set by someone else
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 23)
+  set(CMAKE_CXX_STANDARD 20)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/mtgoparser/CMakeLists.txt
+++ b/mtgoparser/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 # Only set the cxx_standard if it is not set by someone else
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD 23)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -14,7 +14,7 @@
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class [[nodiscard]] Rarity : uint8_t{ Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 
@@ -49,6 +49,16 @@ namespace util {
   // Tags for choosing format for the rarity_as_string function
   struct Short;// C, U, R, M, B
   struct Full;// Common, Uncommon, Rare, Mythic, Booster
+  struct FullLower;// common, uncommon, rare, mythic, booster
+  struct FullUpper;// COMMON, UNCOMMON, RARE, MYTHIC, BOOSTER
+
+  /**
+   * @brief Concept for the rarity formatter tags.
+   *
+   * @tparam Format The rarity formatter tag.
+   */
+  template<class Format>
+  concept rarity_formatter = ::util::mp::is_t_any<Format, Short, Full, FullLower, FullUpper>;
 
   /**
    * @brief Convert a Rarity enum to a string representation in the specified format (`Short` or `Full`).
@@ -61,40 +71,85 @@ namespace util {
    *
    * @return std::string representation of the Rarity enum.
    */
-  template<typename Format>
-  requires ::util::mp::is_t_any<Format, Short, Full>
-  constexpr auto inline rarity_to_string(Rarity rarity) -> std::string
+  template<rarity_formatter Format> constexpr auto inline rarity_to_string(Rarity rarity) -> std::string
   {
-    using ::util::mp::is_t_any;
-    if constexpr (is_t_any<Format, Short>) {
-      switch (rarity) {
-      case Rarity::Common:
-        [[likely]] return "C";
-      case Rarity::Uncommon:
-        [[likely]] return "U";
-      case Rarity::Rare:
+
+    // Aliases for slightly more readability.
+    using shortFormat = std::is_same<Format, Short>;
+    using fullFormat = std::is_same<Format, Full>;
+    using fullLowerFormat = std::is_same<Format, FullLower>;
+    using fullUpperFormat = std::is_same<Format, FullUpper>;
+
+    switch (rarity) {
+    case Rarity::Common:
+      [[likely]] if constexpr (shortFormat::value) { return "C"; }
+      else if constexpr (fullFormat::value)
+      {
+        return "Common";
+      }
+      else if constexpr (fullLowerFormat::value)
+      {
+        return "common";
+      }
+      else if constexpr (fullUpperFormat::value)
+      {
+        return "COMMON";
+      }
+
+    case Rarity::Uncommon:
+      [[likely]] if constexpr (shortFormat::value) { return "U"; }
+      else if constexpr (fullFormat::value)
+      {
+        return "Uncommon";
+      }
+      else if constexpr (fullLowerFormat::value)
+      {
+        return "uncommon";
+      }
+      else if constexpr (fullUpperFormat::value)
+      {
+        return "UNCOMMON";
+      }
+    case Rarity::Rare:
+      if constexpr (shortFormat::value) {
         return "R";
-      case Rarity::Mythic:
-        [[unlikely]] return "M";
-      case Rarity::Booster:
-        [[unlikely]] return "B";
-      }
-    } else if constexpr (is_t_any<Format, Full>) {
-      switch (rarity) {
-      case Rarity::Common:
-        [[likely]] return "Common";
-      case Rarity::Uncommon:
-        [[likely]] return "Uncommon";
-      case Rarity::Rare:
+      } else if constexpr (fullFormat::value) {
         return "Rare";
-      case Rarity::Mythic:
-        [[unlikely]] return "Mythic";
-      case Rarity::Booster:
-        [[unlikely]] return "Booster";
+      } else if constexpr (fullLowerFormat::value) {
+        return "rare";
+      } else if constexpr (fullUpperFormat::value) {
+        return "RARE";
       }
-    } else {
-      static_assert(is_t_any<Format, Short, Full>, "Format must be either mtg::util::Short or mtg::util::Full");
+    case Rarity::Mythic:
+      [[unlikely]] if constexpr (shortFormat::value) { return "M"; }
+      else if constexpr (fullFormat::value)
+      {
+        return "Mythic";
+      }
+      else if constexpr (fullLowerFormat::value)
+      {
+        return "mythic";
+      }
+      else if constexpr (fullUpperFormat::value)
+      {
+        return "MYTHIC";
+      }
+    case Rarity::Booster:
+      [[unlikely]] if constexpr (shortFormat::value) { return "B"; }
+      else if constexpr (fullFormat::value)
+      {
+        return "Booster";
+      }
+      else if constexpr (fullLowerFormat::value)
+      {
+        return "booster";
+      }
+      else if constexpr (fullUpperFormat::value)
+      {
+        return "BOOSTER";
+      }
     }
+
 
     assert(false);
     // If/when C++23 use: std::unreachable();

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -9,11 +9,12 @@
 
 #include <cassert>
 #include <cstdint>
+#include <type_traits>
 
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class [[nodiscard]] Rarity : uint8_t{ Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 
@@ -44,26 +45,52 @@ namespace util {
     return Rarity::Booster;
   }
 
+
+  // Tags for choosing format for the rarity_as_string function
+  struct Short;
+  struct Full;
+
   /**
    * @brief Convert a Rarity enum to a string.
    *
    * @param rarity The Rarity enum to convert
    * @return std::string representation of the Rarity enum.
    */
+  template<typename Format>
+    requires std::is_same_v<Format, Short> || std::is_same_v<Format, Full>
   auto inline rarity_as_string(Rarity rarity) -> std::string
   {
-    switch (rarity) {
-    case Rarity::Common:
-      [[likely]] return "Common";
-    case Rarity::Uncommon:
-      [[likely]] return "Uncommon";
-    case Rarity::Rare:
-      return "Rare";
-    case Rarity::Mythic:
-      [[unlikely]] return "Mythic";
-    case Rarity::Booster:
-      [[unlikely]] return "Booster";
+    if constexpr (std::is_same_v<Format, Short>) {
+      switch (rarity) {
+      case Rarity::Common:
+        [[likely]] return "C";
+      case Rarity::Uncommon:
+        [[likely]] return "U";
+      case Rarity::Rare:
+        return "R";
+      case Rarity::Mythic:
+        [[unlikely]] return "M";
+      case Rarity::Booster:
+        [[unlikely]] return "B";
+      }
+    } else if constexpr (std::is_same_v<Format, Full>) {
+      switch (rarity) {
+      case Rarity::Common:
+        [[likely]] return "Common";
+      case Rarity::Uncommon:
+        [[likely]] return "Uncommon";
+      case Rarity::Rare:
+        return "Rare";
+      case Rarity::Mythic:
+        [[unlikely]] return "Mythic";
+      case Rarity::Booster:
+        [[unlikely]] return "Booster";
+      }
+    } else {
+      static_assert(std::is_same_v<Format, Short> || std::is_same_v<Format, Full>,
+        "Format must be either mtg::util::Short or mtg::util::Full");
     }
+
     assert(false);
     // If/when C++23 use: std::unreachable();
     return "";

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -14,7 +14,7 @@
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t{ Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 
@@ -83,33 +83,15 @@ namespace util {
     switch (rarity) {
     case Rarity::Common:
       [[likely]] if constexpr (shortFormat::value) { return "C"; }
-      else if constexpr (fullFormat::value)
-      {
-        return "Common";
-      }
-      else if constexpr (fullLowerFormat::value)
-      {
-        return "common";
-      }
-      else if constexpr (fullUpperFormat::value)
-      {
-        return "COMMON";
-      }
+      else if constexpr (fullFormat::value) { return "Common"; }
+      else if constexpr (fullLowerFormat::value) { return "common"; }
+      else if constexpr (fullUpperFormat::value) { return "COMMON"; }
 
     case Rarity::Uncommon:
       [[likely]] if constexpr (shortFormat::value) { return "U"; }
-      else if constexpr (fullFormat::value)
-      {
-        return "Uncommon";
-      }
-      else if constexpr (fullLowerFormat::value)
-      {
-        return "uncommon";
-      }
-      else if constexpr (fullUpperFormat::value)
-      {
-        return "UNCOMMON";
-      }
+      else if constexpr (fullFormat::value) { return "Uncommon"; }
+      else if constexpr (fullLowerFormat::value) { return "uncommon"; }
+      else if constexpr (fullUpperFormat::value) { return "UNCOMMON"; }
     case Rarity::Rare:
       if constexpr (shortFormat::value) {
         return "R";
@@ -122,32 +104,14 @@ namespace util {
       }
     case Rarity::Mythic:
       [[unlikely]] if constexpr (shortFormat::value) { return "M"; }
-      else if constexpr (fullFormat::value)
-      {
-        return "Mythic";
-      }
-      else if constexpr (fullLowerFormat::value)
-      {
-        return "mythic";
-      }
-      else if constexpr (fullUpperFormat::value)
-      {
-        return "MYTHIC";
-      }
+      else if constexpr (fullFormat::value) { return "Mythic"; }
+      else if constexpr (fullLowerFormat::value) { return "mythic"; }
+      else if constexpr (fullUpperFormat::value) { return "MYTHIC"; }
     case Rarity::Booster:
       [[unlikely]] if constexpr (shortFormat::value) { return "B"; }
-      else if constexpr (fullFormat::value)
-      {
-        return "Booster";
-      }
-      else if constexpr (fullLowerFormat::value)
-      {
-        return "booster";
-      }
-      else if constexpr (fullUpperFormat::value)
-      {
-        return "BOOSTER";
-      }
+      else if constexpr (fullFormat::value) { return "Booster"; }
+      else if constexpr (fullLowerFormat::value) { return "booster"; }
+      else if constexpr (fullUpperFormat::value) { return "BOOSTER"; }
     }
 
 

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -14,7 +14,7 @@
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t{ Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 
@@ -62,7 +62,7 @@ namespace util {
    * @return std::string representation of the Rarity enum.
    */
   template<typename Format>
-    requires ::util::mp::is_t_any<Format, Short, Full>
+  requires ::util::mp::is_t_any<Format, Short, Full>
   constexpr auto inline rarity_to_string(Rarity rarity) -> std::string
   {
     using ::util::mp::is_t_any;

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -14,7 +14,7 @@
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class [[nodiscard]] Rarity : uint8_t{ Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 
@@ -47,20 +47,26 @@ namespace util {
 
 
   // Tags for choosing format for the rarity_as_string function
-  struct Short;
-  struct Full;
+  struct Short;// C, U, R, M, B
+  struct Full;// Common, Uncommon, Rare, Mythic, Booster
 
   /**
-   * @brief Convert a Rarity enum to a string.
+   * @brief Convert a Rarity enum to a string representation in the specified format (`Short` or `Full`).
    *
-   * @param rarity The Rarity enum to convert
+   * @param rarity The Rarity enum to convert to a string.
+   * @tparam Format The format to use for the string representation (`Short` or `Full`).
+   *
+   * @note The `Short` format uses the first letter of the rarity (e.g. `Rarity::Common` -> "C").
+   * The `Full` format uses the full name of the rarity (e.g. `Rarity::Common` -> "Common").
+   *
    * @return std::string representation of the Rarity enum.
    */
   template<typename Format>
-  requires std::is_same_v<Format, Short> || std::is_same_v<Format, Full>
-  auto inline rarity_as_string(Rarity rarity) -> std::string
+    requires ::util::mp::is_t_any<Format, Short, Full>
+  constexpr auto inline rarity_to_string(Rarity rarity) -> std::string
   {
-    if constexpr (std::is_same_v<Format, Short>) {
+    using ::util::mp::is_t_any;
+    if constexpr (is_t_any<Format, Short>) {
       switch (rarity) {
       case Rarity::Common:
         [[likely]] return "C";
@@ -73,7 +79,7 @@ namespace util {
       case Rarity::Booster:
         [[unlikely]] return "B";
       }
-    } else if constexpr (std::is_same_v<Format, Full>) {
+    } else if constexpr (is_t_any<Format, Full>) {
       switch (rarity) {
       case Rarity::Common:
         [[likely]] return "Common";
@@ -87,8 +93,7 @@ namespace util {
         [[unlikely]] return "Booster";
       }
     } else {
-      static_assert(std::is_same_v<Format, Short> || std::is_same_v<Format, Full>,
-        "Format must be either mtg::util::Short or mtg::util::Full");
+      static_assert(is_t_any<Format, Short, Full>, "Format must be either mtg::util::Short or mtg::util::Full");
     }
 
     assert(false);

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -14,7 +14,7 @@
 namespace mtg {
 
 // Denote the rarity of an MTG item.
-enum class [[nodiscard]] Rarity : uint8_t { Common, Uncommon, Rare, Mythic, Booster };
+enum class [[nodiscard]] Rarity : uint8_t{ Common, Uncommon, Rare, Mythic, Booster };
 
 namespace util {
 
@@ -57,7 +57,7 @@ namespace util {
    * @return std::string representation of the Rarity enum.
    */
   template<typename Format>
-    requires std::is_same_v<Format, Short> || std::is_same_v<Format, Full>
+  requires std::is_same_v<Format, Short> || std::is_same_v<Format, Full>
   auto inline rarity_as_string(Rarity rarity) -> std::string
   {
     if constexpr (std::is_same_v<Format, Short>) {

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -24,7 +24,6 @@ namespace mtgo {
 class Collection
 {
   // Member variables
-  // TODO: Add timestamp
   std::vector<Card> cards_;
 
   // Memoization

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -183,7 +183,7 @@ void inline Collection::Print() const
       card.quantity_,
       card.set_,
       card.foil_,
-      mtg::util::rarity_as_string<mtg::util::Full>(card.rarity_));
+      mtg::util::rarity_to_string<mtg::util::Full>(card.rarity_));
   }
 }
 
@@ -206,7 +206,7 @@ void inline Collection::PrettyPrint() const
       scryfall_price,
       card.quantity_,
       card.foil_,
-      mtg::util::rarity_as_string<mtg::util::Full>(card.rarity_),
+      mtg::util::rarity_to_string<mtg::util::Full>(card.rarity_),
       card.set_);
   }
 }

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -183,7 +183,7 @@ void inline Collection::Print() const
       card.quantity_,
       card.set_,
       card.foil_,
-      mtg::util::rarity_as_string(card.rarity_));
+      mtg::util::rarity_as_string<mtg::util::Full>(card.rarity_));
   }
 }
 
@@ -206,7 +206,7 @@ void inline Collection::PrettyPrint() const
       scryfall_price,
       card.quantity_,
       card.foil_,
-      mtg::util::rarity_as_string(card.rarity_),
+      mtg::util::rarity_as_string<mtg::util::Full>(card.rarity_),
       card.set_);
   }
 }

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -70,7 +70,7 @@ struct [[nodiscard]] CardHistory
   csv_row += ',';
   csv_row += card_hist.set_;
   csv_row += ',';
-  csv_row += mtg::util::rarity_as_short_string(card_hist.rarity_);
+  csv_row += mtg::util::rarity_as_string<mtg::util::Short>(card_hist.rarity_);
   csv_row += ',';
 
   // Reduce branching

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -1,6 +1,7 @@
 
 #include "mtgoparser/mtg.hpp"
 
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <tuple>
@@ -63,17 +64,13 @@ struct [[nodiscard]] CardHistory
   csv_row.reserve(512);
 
   csv_row += std::to_string(card_hist.id_);
-  csv_row += ',';
-  csv_row += card_hist.quantity_;
-  csv_row += ',';
-  csv_row += card_hist.name_;
-  csv_row += ',';
-  csv_row += card_hist.set_;
-  csv_row += ',';
-  csv_row += mtg::util::rarity_as_string<mtg::util::Short>(card_hist.rarity_);
-  csv_row += ',';
+  csv_row += ',' + card_hist.quantity_;
+  csv_row += ',' + card_hist.name_;
+  csv_row += ',' + card_hist.set_;
+  csv_row += ',' + mtg::util::rarity_to_string<mtg::util::Short>(card_hist.rarity_);
 
-  // Reduce branching
+  csv_row += ',';
+  // Reduce branching by using a constexpr array of strings and indexing into it with the bool value.
   constexpr std::array is_foil_str = { "false", "true" };
   csv_row += is_foil_str[boost::implicit_cast<uint8_t>(card_hist.foil_)];
 

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -57,4 +57,35 @@ struct [[nodiscard]] CardHistory
   CardHistory &operator=(const CardHistory &) = delete;
 };
 
+[[nodiscard]] inline auto card_history_to_csv_row(CardHistory &&card_hist) -> std::string
+{
+  std::string csv_row;
+  csv_row.reserve(512);
+
+  csv_row += std::to_string(card_hist.id_);
+  csv_row += ',';
+  csv_row += card_hist.quantity_;
+  csv_row += ',';
+  csv_row += card_hist.name_;
+  csv_row += ',';
+  csv_row += card_hist.set_;
+  csv_row += ',';
+  csv_row += mtg::util::rarity_as_short_string(card_hist.rarity_);
+  csv_row += ',';
+
+  // Reduce branching
+  constexpr std::array is_foil_str = { "false", "true" };
+  csv_row += is_foil_str[boost::implicit_cast<uint8_t>(card_hist.foil_)];
+
+  for (auto &&[quantity, gb_price, scry_price] : card_hist.price_history_) {
+    csv_row += ',';
+    csv_row += quantity ? fmt::format("[{}]", quantity.value()) : "";
+    csv_row += gb_price ? fmt::format("{:g}", gb_price.value()) : "-";
+    csv_row += ';';
+    csv_row += scry_price ? fmt::format("{:g}", scry_price.value()) : "-";
+  }
+
+  return csv_row;
+}
+
 }// namespace mtgo

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -71,8 +71,7 @@ struct [[nodiscard]] CardHistory
 
   csv_row += ',';
   // Reduce branching by using a constexpr array of strings and indexing into it with the bool value.
-  constexpr std::array is_foil_str = { "false", "true" };
-  csv_row += is_foil_str[boost::implicit_cast<uint8_t>(card_hist.foil_)];
+  csv_row += util::optimization::branchless_if(card_hist.foil_, "false", "true");
 
   for (auto &&[quantity, gb_price, scry_price] : card_hist.price_history_) {
     csv_row += ',';

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -1,0 +1,49 @@
+
+#include "mtgoparser/mtg.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+using opt_float_t = std::optional<float>;
+using opt_uint_t = std::optional<uint16_t>;
+
+using tup_quant_and_prices_t = std::tuple<opt_uint_t, opt_float_t, opt_float_t>;
+
+namespace mtgo {
+
+
+struct [[nodiscard]] CardHistory
+{
+  uint32_t id_;
+  std::string quantity_;
+  std::string name_;
+  std::string set_;
+  mtg::Rarity rarity_;
+  bool foil_;
+  std::vector<tup_quant_and_prices_t> price_history_;
+
+  explicit CardHistory(uint32_t id,
+    std::string &&quantity,
+    std::string &&name,
+    std::string &&set,
+    mtg::Rarity rarity,
+    bool foil,
+    std::vector<tup_quant_and_prices_t> &&price_history) noexcept
+    : id_(id), quantity_(quantity), name_(std::move(name)), set_(std::move(set)), rarity_(rarity), foil_(foil),
+      price_history_(std::move(price_history))
+  {}
+
+  // Move constructor
+  [[nodiscard]] CardHistory(CardHistory &&other) noexcept
+    : id_(other.id_), quantity_(std::move(other.quantity_)), name_(std::move(other.name_)), set_(std::move(other.set_)),
+      rarity_(other.rarity_), foil_(other.foil_), price_history_(std::move(other.price_history_))
+  {}
+
+  // Delete copy && assignment constructor
+  CardHistory(const CardHistory &) = delete;
+  CardHistory &operator=(const CardHistory &) = delete;
+};
+
+}// namespace mtgo

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -14,6 +14,19 @@ using tup_quant_and_prices_t = std::tuple<opt_uint_t, opt_float_t, opt_float_t>;
 namespace mtgo {
 
 
+/// Helper struct to so that `CardHistory` can be constructed with designated initializers for the fields with matching
+/// types.
+struct [[nodiscard]] QuantityNameSet
+{
+  std::string quantity_;
+  std::string name_;
+  std::string set_;
+};
+
+/**
+ * @brief Holds the history of a card in terms of its price and quantity.
+ *
+ */
 struct [[nodiscard]] CardHistory
 {
   uint32_t id_;
@@ -25,14 +38,12 @@ struct [[nodiscard]] CardHistory
   std::vector<tup_quant_and_prices_t> price_history_;
 
   explicit CardHistory(uint32_t id,
-    std::string &&quantity,
-    std::string &&name,
-    std::string &&set,
+    QuantityNameSet &&qns,
     mtg::Rarity rarity,
     bool foil,
     std::vector<tup_quant_and_prices_t> &&price_history) noexcept
-    : id_(id), quantity_(quantity), name_(std::move(name)), set_(std::move(set)), rarity_(rarity), foil_(foil),
-      price_history_(std::move(price_history))
+    : id_(id), quantity_(qns.quantity_), name_(std::move(qns.name_)), set_(std::move(qns.set_)), rarity_(rarity),
+      foil_(foil), price_history_(std::move(price_history))
   {}
 
   // Move constructor

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -4,6 +4,7 @@
 
 #include <boost/implicit_cast.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <optional>
 #include <span>
@@ -103,7 +104,10 @@ using tup_quant_and_prices_t = std::tuple<opt_uint_t, opt_float_t, opt_float_t>;
   std::vector<tup_quant_and_prices_t> quant_and_prices;
   quant_and_prices.reserve(span_of_str.size());
 
-  for (const auto &str : span_of_str) { quant_and_prices.emplace_back(parse_quant_and_prices(str)); }
+  std::transform(
+    span_of_str.begin(), span_of_str.end(), std::back_inserter(quant_and_prices), [](const std::string &str) {
+      return parse_quant_and_prices(str);
+    });
 
   return quant_and_prices;
 }

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -20,7 +20,7 @@
 namespace mtgo::csv {
 
 
-// Function to split a string_view into a vector of sub-views based on a delimiter
+// Splits a string into a vector of sub-strings based on a delimiter
 [[nodiscard]] inline auto into_substr_vec(const std::string &str, char delimiter) -> std::vector<std::string>
 {
   std::vector<std::string> sub_strs;
@@ -44,6 +44,13 @@ using opt_uint_t = std::optional<uint16_t>;
 
 using tup_quant_and_prices_t = std::tuple<opt_uint_t, opt_float_t, opt_float_t>;
 
+/**
+ * @brief Parse a string of the form "[quantity]goatbots_price;scryfall_price" into a tuple of the form: {quantity,
+ * goatbots_price, scryfall_price}.
+ *
+ * @param str
+ * @return tup_quant_and_prices_t
+ */
 [[nodiscard]] inline auto parse_quant_and_prices(const std::string &str) -> tup_quant_and_prices_t
 {
 
@@ -81,6 +88,14 @@ using tup_quant_and_prices_t = std::tuple<opt_uint_t, opt_float_t, opt_float_t>;
   return { quantity, gb_price, scryfall_price };
 }
 
+/**
+ * @brief Parse a span of strings of the form "[quantity]goatbots_price;scryfall_price" into a vector of tuples
+ * of the form: {quantity, goatbots_price, scryfall_price}.
+ *
+ * @param span
+ * @return std::vector<tup_quant_and_prices_t> A vector of tuples of the form: {quantity, goatbots_price,
+ * scryfall_price}
+ */
 [[nodiscard]] inline auto quant_and_prices_from_span(const std::span<std::string> &span)
   -> std::vector<tup_quant_and_prices_t>
 {

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
+#include <iterator>
 #include <optional>
 #include <span>
 #include <string>

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <optional>
+#include <span>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -92,17 +93,17 @@ using tup_quant_and_prices_t = std::tuple<opt_uint_t, opt_float_t, opt_float_t>;
  * @brief Parse a span of strings of the form "[quantity]goatbots_price;scryfall_price" into a vector of tuples
  * of the form: {quantity, goatbots_price, scryfall_price}.
  *
- * @param span
+ * @param span_of_str
  * @return std::vector<tup_quant_and_prices_t> A vector of tuples of the form: {quantity, goatbots_price,
  * scryfall_price}
  */
-[[nodiscard]] inline auto quant_and_prices_from_span(const std::span<std::string> &span)
+[[nodiscard]] inline auto quant_and_prices_from_span(const std::span<std::string> &span_of_str)
   -> std::vector<tup_quant_and_prices_t>
 {
   std::vector<tup_quant_and_prices_t> quant_and_prices;
-  quant_and_prices.reserve(span.size());
+  quant_and_prices.reserve(span_of_str.size());
 
-  for (const auto &str : span) { quant_and_prices.emplace_back(parse_quant_and_prices(str)); }
+  for (const auto &str : span_of_str) { quant_and_prices.emplace_back(parse_quant_and_prices(str)); }
 
   return quant_and_prices;
 }

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -3,8 +3,7 @@
 #include <boost/implicit_cast.hpp>
 
 #include <optional>
-#include <sstream>
-#include <string_view>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -44,24 +43,17 @@ using opt_float_t = std::optional<float>;
   [[maybe_unused]] std::size_t size = str.size();
   LLVM_ASSUME(size < 32);
 
-  std::istringstream ss(str);
+  constexpr char delimiter = ';';
+  const std::size_t delim_pos = str.find(delimiter);
+  const std::string gb_price_str = str.substr(0, delim_pos);
+  const std::string scryfall_opt_str = str.substr(delim_pos + 1);
 
-  opt_float_t first_val{};
-  opt_float_t second_val{};
 
-  if (ss.peek() == '-') {
-    ss.ignore();
-  } else {
-    ss >> *first_val;
-  }
-  ss.ignore();
-  if (ss.peek() == '-') {
-    ss.ignore();
-  } else {
-    ss >> *second_val;
-  }
+  opt_float_t first = gb_price_str == "-" ? boost::implicit_cast<opt_float_t>(std::nullopt) : std::stof(gb_price_str);
+  opt_float_t second =
+    scryfall_opt_str == "-" ? boost::implicit_cast<opt_float_t>(std::nullopt) : std::stof(scryfall_opt_str);
 
-  return std::make_pair(first_val, second_val);
+  return std::make_pair(first, second);
 }
 
 }// namespace mtgo::csv

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -59,4 +59,16 @@ using opt_float_t = std::optional<float>;
   return std::make_pair(gb_price, scryfall_price);
 }
 
+[[nodiscard]] inline auto floats_from_span(const std::span<std::string> &span)
+  -> std::vector<std::pair<opt_float_t, opt_float_t>>
+{
+  std::vector<std::pair<opt_float_t, opt_float_t>> floats;
+  floats.reserve(span.size());
+
+  for (const auto &str : span) { floats.push_back(str_to_floats(str)); }
+
+  return floats;
+}
+
+
 }// namespace mtgo::csv

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -17,7 +17,7 @@ namespace mtgo::csv {
 
 
 // Function to split a string_view into a vector of sub-views based on a delimiter
-[[nodiscard]] inline auto constexpr into_substr_vec(const std::string &str, char delimiter) -> std::vector<std::string>
+[[nodiscard]] inline auto into_substr_vec(const std::string &str, char delimiter) -> std::vector<std::string>
 {
   std::vector<std::string> sub_strs;
   std::size_t start = 0;

--- a/mtgoparser/include/mtgoparser/mtgo/csv.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/csv.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <boost/cstdfloat.hpp>
+#include <boost/implicit_cast.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#ifdef __llvm__
+#define LLVM_ASSUME(expr) __builtin_assume(expr)
+#else
+#define LLVM_ASSUME(expr) ((void)0)
+#endif
+
+
+// Function to split a string_view into a vector of sub-views based on a delimiter
+[[nodiscard]] inline auto constexpr into_token_vec(std::string_view str, char delimiter)
+  -> std::vector<std::string_view>
+{
+  std::vector<std::string_view> sub_views;
+  std::size_t start = 0;
+  std::size_t end = str.find(delimiter);
+
+  while (end != std::string_view::npos) {
+    sub_views.push_back(str.substr(start, end - start));
+    start = end + 1;
+    end = str.find(delimiter, start);
+  }
+
+  // Add the last token
+  sub_views.push_back(str.substr(start));
+
+  return sub_views;
+}
+
+using opt_float_t = std::optional<boost::float32_t>;
+
+// Function to parse a string into two floats, handling the case where a hyphen signifies a missing value
+[[nodiscard]] inline auto sv_to_floats(std::string_view str) -> std::pair<opt_float_t, opt_float_t>
+{
+
+
+  [[maybe_unused]] std::size_t size = str.size();
+  LLVM_ASSUME(size < 32);
+
+
+  constexpr char delimiter = ';';
+  std::size_t delim_pos = str.find(delimiter);
+  std::string_view gb_price_str = str.substr(0, delim_pos);
+  std::string_view scryfall_opt_str = str.substr(delim_pos + 1);
+
+
+  opt_float_t first = gb_price_str == "-" ? boost::implicit_cast<opt_float_t>(std::nullopt)
+                                          : boost::lexical_cast<float32_t>(gb_price_str);
+  opt_float_t second = scryfall_opt_str == "-" ? boost::implicit_cast<opt_float_t>(std::nullopt)
+                                               : boost::lexical_cast<float32_t>(scryfall_opt_str);
+  return std::make_pair(first, second);
+}

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -108,3 +108,32 @@ template<typename T, typename... CompareToTypes>
 inline constexpr bool is_t_same = std::conjunction_v<std::is_same<T, CompareToTypes>...>;
 
 }// namespace util::mp
+
+namespace util::optimization {
+
+/**
+ * @brief Branchless if statement that returns either `true_val` or `false_val` depending on
+ * `cond`.
+ *
+ * @warning Profile before committing! This function is SLOWER if any of the following are true: The branch is rarely
+ * mispredicted, the values are expensive to evaluate, or the compiler already does a branchless optimization (always
+ * preferred).
+ *
+ * @note The tradeoff is that both `true_val` and `false_val` are evaluated, so if they are
+ * expensive to evaluate then this function is not useful. This function is useful when the values are cheap to evaluate
+ * and the branch is likely to be mispredicted (i.e. there's no clear pattern to the values of `cond`).
+ *
+ * @tparam T Type of the return value.
+ * @param cond The condition to check.
+ * @param true_val The value to return if `cond` is true.
+ * @param false_val The value to return if `cond` is false.
+ * @return T Either `true_val` or `false_val` depending on `cond`.
+ */
+template<typename T> [[nodiscard]] inline constexpr auto branchless_if(bool cond, T false_val, T true_val) -> T
+{
+  std::array ret_vals = { false_val, true_val };
+  return ret_vals[boost::implicit_cast<uint8_t>(cond)];
+}
+
+
+}// namespace util::optimization

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -3,6 +3,8 @@
 #include <optional>
 #include <string_view>
 
+#include <fmt/core.h>
+
 #include <boost/outcome.hpp>
 #include <boost/outcome/result.hpp>
 
@@ -28,7 +30,7 @@ using ErrorStr = std::string;
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename SB>
-requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
+  requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
 [[nodiscard]] inline constexpr auto is_sv_same(SA a_sv, SB b_sv) -> bool
 {
   return boost::implicit_cast<std::string_view>(a_sv) == boost::implicit_cast<std::string_view>(b_sv);
@@ -51,8 +53,8 @@ requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, st
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename... Ss>
-requires std::convertible_to<SA, std::string_view> &&(std::convertible_to<Ss, std::string_view> || ...)
-  [[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
+  requires std::convertible_to<SA, std::string_view> && (std::convertible_to<Ss, std::string_view> || ...)
+[[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
 {
   return (is_sv_same(a_sv, bs_svs) || ...);
 }

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -30,7 +30,7 @@ using ErrorStr = std::string;
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename SB>
-  requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
+requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
 [[nodiscard]] inline constexpr auto is_sv_same(SA a_sv, SB b_sv) -> bool
 {
   return boost::implicit_cast<std::string_view>(a_sv) == boost::implicit_cast<std::string_view>(b_sv);
@@ -53,8 +53,8 @@ template<typename SA, typename SB>
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename... Ss>
-  requires std::convertible_to<SA, std::string_view> && (std::convertible_to<Ss, std::string_view> || ...)
-[[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
+requires std::convertible_to<SA, std::string_view> &&(std::convertible_to<Ss, std::string_view> || ...)
+  [[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
 {
   return (is_sv_same(a_sv, bs_svs) || ...);
 }

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -30,7 +30,7 @@ using ErrorStr = std::string;
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename SB>
-requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
+  requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, std::string_view>
 [[nodiscard]] inline constexpr auto is_sv_same(SA a_sv, SB b_sv) -> bool
 {
   return boost::implicit_cast<std::string_view>(a_sv) == boost::implicit_cast<std::string_view>(b_sv);
@@ -53,12 +53,11 @@ requires std::convertible_to<SA, std::string_view> && std::convertible_to<SB, st
  * @note The string-like values are converted to `std::string_view` before the comparison.
  */
 template<typename SA, typename... Ss>
-requires std::convertible_to<SA, std::string_view> &&(std::convertible_to<Ss, std::string_view> || ...)
-  [[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
+  requires std::convertible_to<SA, std::string_view> && (std::convertible_to<Ss, std::string_view> || ...)
+[[nodiscard]] inline constexpr auto is_sv_any_of(SA a_sv, Ss... bs_svs) -> bool
 {
   return (is_sv_same(a_sv, bs_svs) || ...);
 }
-
 
 /**
  * @brief Convert a `string_view` to an unsigned integer.
@@ -84,4 +83,28 @@ template<typename T_uint> [[nodiscard]] inline auto sv_to_uint(std::string_view 
     return outcome::failure(fmt::format("Failed to convert string_view `{}` to uint", sv));
   }
 }
+
+namespace mp {
+
+  /**
+   * @brief Returns true if a type is the same as any of the other types.
+   *
+   * @tparam T The type to compare against.
+   * @tparam CompareToTypes The types to compare with.
+   */
+  template<typename T, typename... CompareToTypes>
+  inline constexpr bool is_t_any = std::disjunction_v<std::is_same<T, CompareToTypes>...>;
+
+
+  /**
+   * @brief Returns true if a type is the same as all of the other types.
+   *
+   * @tparam T The type to compare against.
+   * @tparam CompareToTypes The types to compare with.
+   */
+  template<typename T, typename... CompareToTypes>
+  inline constexpr bool is_t_same = std::conjunction_v<std::is_same<T, CompareToTypes>...>;
+
+}// namespace mp
+
 }// namespace util

--- a/mtgoparser/include/mtgoparser/util.hpp
+++ b/mtgoparser/include/mtgoparser/util.hpp
@@ -84,27 +84,27 @@ template<typename T_uint> [[nodiscard]] inline auto sv_to_uint(std::string_view 
   }
 }
 
-namespace mp {
-
-  /**
-   * @brief Returns true if a type is the same as any of the other types.
-   *
-   * @tparam T The type to compare against.
-   * @tparam CompareToTypes The types to compare with.
-   */
-  template<typename T, typename... CompareToTypes>
-  inline constexpr bool is_t_any = std::disjunction_v<std::is_same<T, CompareToTypes>...>;
-
-
-  /**
-   * @brief Returns true if a type is the same as all of the other types.
-   *
-   * @tparam T The type to compare against.
-   * @tparam CompareToTypes The types to compare with.
-   */
-  template<typename T, typename... CompareToTypes>
-  inline constexpr bool is_t_same = std::conjunction_v<std::is_same<T, CompareToTypes>...>;
-
-}// namespace mp
-
 }// namespace util
+
+namespace util::mp {
+
+/**
+ * @brief Returns true if a type is the same as any of the other types.
+ *
+ * @tparam T The type to compare against.
+ * @tparam CompareToTypes The types to compare with.
+ */
+template<typename T, typename... CompareToTypes>
+inline constexpr bool is_t_any = std::disjunction_v<std::is_same<T, CompareToTypes>...>;
+
+
+/**
+ * @brief Returns true if a type is the same as all of the other types.
+ *
+ * @tparam T The type to compare against.
+ * @tparam CompareToTypes The types to compare with.
+ */
+template<typename T, typename... CompareToTypes>
+inline constexpr bool is_t_same = std::conjunction_v<std::is_same<T, CompareToTypes>...>;
+
+}// namespace util::mp

--- a/mtgoparser/src/mtgo_preprocessor/run.cpp
+++ b/mtgoparser/src/mtgo_preprocessor/run.cpp
@@ -68,7 +68,7 @@ namespace helper {
   auto write_json_to_appdata_dir(JsonAndDestinationDir jsonAndDir) -> outcome::result<void, std::string>
   {
     const std::string fname{ "mtgo-cards" };
-    const std::string ext{ ".json" };
+    const std::string ext{ "json" };
     std::filesystem::path save_path = jsonAndDir.dir;
     save_path.append("collection-history");
     save_path.append(fname);

--- a/mtgoparser/test/CMakeLists.txt
+++ b/mtgoparser/test/CMakeLists.txt
@@ -165,3 +165,24 @@ catch_discover_tests(
   "test_full_collection_parse."
   OUTPUT_SUFFIX
   .xml)
+
+# Tests of CSV parsing functionality
+add_executable(test_csv_parse test_csv_parse.cpp)
+target_link_libraries(test_csv_parse PRIVATE
+                                     mtgoparser::mtgoparser_warnings
+                                     mtgoparser::mtgoparser_options
+                                     mtgoparser)
+target_link_system_library(test_csv_parse PRIVATE Catch2::Catch2WithMain)
+
+catch_discover_tests(
+  test_csv_parse
+  TEST_PREFIX
+  "test_csv_parse."
+  REPORTER
+  XML
+  OUTPUT_DIR
+  .
+  OUTPUT_PREFIX
+  "test_csv_parse."
+  OUTPUT_SUFFIX
+  .xml)

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -327,6 +327,13 @@ TEST_CASE("mtgo::csv::floats_from_span")
     CHECK(card_history.rarity_ == mtg::Rarity::Rare);
     CHECK(card_history.foil_ == false);
     CHECK(card_history.price_history_.size() == 3);
+
+    SECTION("mtgo::card_history_to_csv_row")
+    {
+      std::string csv_row = mtgo::card_history_to_csv_row(std::move(card_history));
+      INFO("csv_row:\n" << csv_row);
+      CHECK(csv_row == rows.at(1));
+    }
   }
 }
 

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -21,16 +21,16 @@ TEST_CASE("mtgo::csv::into_substr_vec")
   const std::string test_csv_data =
     R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
 120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2.0;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2.0;2.1,[0]0.9;-)";
+106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
+106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
 
   std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
   REQUIRE(rows.size() == 4);
 
   CHECK(rows.at(0) == "id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z");
   CHECK(rows.at(1) == "120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3");
-  CHECK(rows.at(2) == "106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2.0;2.1,[11]0.9;-");
-  CHECK(rows.at(3) == "106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2.0;2.1,[0]0.9;-");
+  CHECK(rows.at(2) == "106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-");
+  CHECK(rows.at(3) == "106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-");
 
 
   auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
@@ -118,8 +118,8 @@ TEST_CASE("mtgo::csv::into_substr_vec & mtgo::csv::str_to_floats")
   const std::string test_csv_data =
     R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
 120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2.0;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2.0;2.1,[0]0.9;-)";
+106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
+106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
 
   std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
   REQUIRE(rows.size() == 4);
@@ -210,8 +210,8 @@ TEST_CASE("mtgo::csv::floats_from_span")
     const std::string test_csv_data =
       R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
 120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2.0;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2.0;2.1,[0]0.9;-)";
+106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
+106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
 
     std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
     REQUIRE(rows.size() == 4);

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -40,6 +40,51 @@ TEST_CASE("mtgo::csv")
   CHECK(headers.at(6) == "2023-11-06T083944Z");
   CHECK(headers.at(7) == "2023-11-06T115147Z");
   CHECK(headers.at(8) == "2023-11-08T084732Z");
+
+  SECTION("mtgo::csv::str_to_floats")
+  {
+    auto [a0, b0] = mtgo::csv::str_to_floats("0.72;0.1");
+    INFO("a0: " << a0.value_or(-1.0f));
+    INFO("b0: " << b0.value_or(-1.0f));
+    REQUIRE(a0.has_value());
+    REQUIRE(b0.has_value());
+    CHECK(a0.value() == 0.72f);
+    CHECK(b0.value() == 0.1f);
+
+    auto [a01, b01] = mtgo::csv::str_to_floats("0.002;12.1");
+    CHECK(a01.has_value());
+    CHECK(b01.has_value());
+    CHECK(a01.value() == 0.002f);
+    CHECK(b01.value() == 12.1f);
+
+    auto [a1, b1] = mtgo::csv::str_to_floats("0.72;-");
+    CHECK(a1.has_value());
+    CHECK_FALSE(b1.has_value());
+    CHECK(a1.value() == 0.72f);
+
+    auto [a2, b2] = mtgo::csv::str_to_floats("-;0.1");
+    CHECK_FALSE(a2.has_value());
+    CHECK(b2.has_value());
+    CHECK(b2.value() == 0.1f);
+
+    auto [a3, b3] = mtgo::csv::str_to_floats("-;-");
+    CHECK_FALSE(a3.has_value());
+    CHECK_FALSE(b3.has_value());
+
+    // With more than two values
+    auto [a4, b4] = mtgo::csv::str_to_floats("0.72;0.1;0.2");
+    CHECK(a4.has_value());
+    CHECK(b4.has_value());
+    CHECK(a4.value() == 0.72f);
+    CHECK(b4.value() == 0.1f);
+
+    // With integer values
+    auto [a5, b5] = mtgo::csv::str_to_floats("1;2");
+    CHECK(a5.has_value());
+    CHECK(b5.has_value());
+    CHECK(a5.value() == 1.0f);
+    CHECK(b5.value() == 2.0f);
+  }
 }
 
 // NOLINTEND

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -1,0 +1,45 @@
+// NOLINTBEGIN
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <fmt/core.h>
+
+#include <mtgoparser/mtgo/csv.hpp>
+
+#include <utility>
+
+using Catch::Matchers::ContainsSubstring;
+
+const std::string test_csv_data =
+  R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
+120020,1,In the Darkness Bind Them,LTC,R,false,0.72;0.1,0.78;-,0.4;0.3
+106729,1,Razorverge Thicket,ONE,R,false,1.1;0.9,2.0;2.1,0.9;-
+106729,1,Razorverge Thicket,THR,R,false,-;-,2.0;2.1,0.9;-)";
+
+TEST_CASE("mtgo::csv")
+{
+  std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+  REQUIRE(rows.size() == 4);
+
+  CHECK(rows.at(0) == "id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z");
+  CHECK(rows.at(1) == "120020,1,In the Darkness Bind Them,LTC,R,false,0.72;0.1,0.78;-,0.4;0.3");
+  CHECK(rows.at(2) == "106729,1,Razorverge Thicket,ONE,R,false,1.1;0.9,2.0;2.1,0.9;-");
+  CHECK(rows.at(3) == "106729,1,Razorverge Thicket,THR,R,false,-;-,2.0;2.1,0.9;-");
+
+
+  auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
+  REQUIRE(headers.size() == 9);
+
+  CHECK(headers.at(0) == "id");
+  CHECK(headers.at(1) == "quantity");
+  CHECK(headers.at(2) == "name");
+  CHECK(headers.at(3) == "set");
+  CHECK(headers.at(4) == "rarity");
+  CHECK(headers.at(5) == "foil");
+  CHECK(headers.at(6) == "2023-11-06T083944Z");
+  CHECK(headers.at(7) == "2023-11-06T115147Z");
+  CHECK(headers.at(8) == "2023-11-08T084732Z");
+}
+
+// NOLINTEND

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -312,15 +312,16 @@ TEST_CASE("mtgo::csv::floats_from_span")
     auto id_res = util::sv_to_uint<uint32_t>(row1.at(0));
     REQUIRE(id_res.has_value());
 
-    mtgo::CardHistory card_history{ id_res.value(),
-      std::move(row1.at(1)),
-      std::move(row1.at(2)),
-      std::move(row1.at(3)),
-      mtg::util::rarity_from_t(row1.at(4)),
-      false,
-      std::move(q_gb_sc) };
+    mtgo::QuantityNameSet qns{
+      .quantity_ = std::move(row1.at(1)), .name_ = std::move(row1.at(2)), .set_ = std::move(row1.at(3))
+    };
+
+    mtgo::CardHistory card_history{
+      id_res.value(), std::move(qns), mtg::util::rarity_from_t(row1.at(4)), false, std::move(q_gb_sc)
+    };
 
     CHECK(card_history.id_ == 120020);
+    CHECK(card_history.quantity_ == "1");
     CHECK(card_history.name_ == "In the Darkness Bind Them");
     CHECK(card_history.set_ == "LTC");
     CHECK(card_history.rarity_ == mtg::Rarity::Rare);

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -423,6 +423,14 @@ TEST_CASE("mtgo::csv::floats_from_span")
       std::string csv_row3 = mtgo::card_history_to_csv_row(std::move(card_history3));
       INFO("csv_row3:\n" << csv_row3);
       CHECK(csv_row3 == rows.at(3));
+
+      std::string serialized_csv = fmt::format("{}\n", rows[0]);
+      serialized_csv += csv_row1 + '\n';
+      serialized_csv += csv_row2 + '\n';
+      serialized_csv += csv_row3;
+
+      INFO("serialized_csv:\n" << serialized_csv);
+      CHECK(serialized_csv == test_csv_data);
     }
   }
 }

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -11,14 +11,15 @@
 
 using Catch::Matchers::ContainsSubstring;
 
-const std::string test_csv_data =
-  R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
+
+TEST_CASE("mtgo::csv::into_substr_vec")
+{
+  const std::string test_csv_data =
+    R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
 120020,1,In the Darkness Bind Them,LTC,R,false,0.72;0.1,0.78;-,0.4;0.3
 106729,1,Razorverge Thicket,ONE,R,false,1.1;0.9,2.0;2.1,0.9;-
 106729,1,Razorverge Thicket,THR,R,false,-;-,2.0;2.1,0.9;-)";
 
-TEST_CASE("mtgo::csv")
-{
   std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
   REQUIRE(rows.size() == 4);
 
@@ -40,50 +41,120 @@ TEST_CASE("mtgo::csv")
   CHECK(headers.at(6) == "2023-11-06T083944Z");
   CHECK(headers.at(7) == "2023-11-06T115147Z");
   CHECK(headers.at(8) == "2023-11-08T084732Z");
+}
 
-  SECTION("mtgo::csv::str_to_floats")
+TEST_CASE("mtgo::csv::str_to_floats")
+{
+  auto [a0, b0] = mtgo::csv::str_to_floats("0.72;0.1");
+  INFO("a0: " << a0.value_or(-1.0f));
+  INFO("b0: " << b0.value_or(-1.0f));
+  REQUIRE(a0.has_value());
+  REQUIRE(b0.has_value());
+  CHECK(a0.value() == 0.72f);
+  CHECK(b0.value() == 0.1f);
+
+  auto [a01, b01] = mtgo::csv::str_to_floats("0.002;12.1");
+  CHECK(a01.has_value());
+  CHECK(b01.has_value());
+  CHECK(a01.value() == 0.002f);
+  CHECK(b01.value() == 12.1f);
+
+  auto [a1, b1] = mtgo::csv::str_to_floats("0.72;-");
+  CHECK(a1.has_value());
+  CHECK_FALSE(b1.has_value());
+  CHECK(a1.value() == 0.72f);
+
+  auto [a2, b2] = mtgo::csv::str_to_floats("-;0.1");
+  CHECK_FALSE(a2.has_value());
+  CHECK(b2.has_value());
+  CHECK(b2.value() == 0.1f);
+
+  auto [a3, b3] = mtgo::csv::str_to_floats("-;-");
+  CHECK_FALSE(a3.has_value());
+  CHECK_FALSE(b3.has_value());
+
+  // With more than two values
+  auto [a4, b4] = mtgo::csv::str_to_floats("0.72;0.1;0.2");
+  CHECK(a4.has_value());
+  CHECK(b4.has_value());
+  CHECK(a4.value() == 0.72f);
+  CHECK(b4.value() == 0.1f);
+
+  // With integer values
+  auto [a5, b5] = mtgo::csv::str_to_floats("1;2");
+  CHECK(a5.has_value());
+  CHECK(b5.has_value());
+  CHECK(a5.value() == 1.0f);
+  CHECK(b5.value() == 2.0f);
+}
+
+
+TEST_CASE("mtgo::csv::into_substr_vec & mtgo::csv::str_to_floats")
+{
+  const std::string test_csv_data =
+    R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
+120020,1,In the Darkness Bind Them,LTC,R,false,0.72;0.1,0.78;-,0.4;0.3
+106729,1,Razorverge Thicket,ONE,R,false,1.1;0.9,2.0;2.1,0.9;-
+106729,1,Razorverge Thicket,THR,R,false,-;-,2.0;2.1,0.9;-)";
+
+  std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+  REQUIRE(rows.size() == 4);
+
+  auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
+  REQUIRE(headers.size() == 9);
+
+  auto row1 = mtgo::csv::into_substr_vec(rows.at(1), ',');
+  REQUIRE(row1.size() == 9);
+
+  auto row2 = mtgo::csv::into_substr_vec(rows.at(2), ',');
+  REQUIRE(row2.size() == 9);
+
+  auto row3 = mtgo::csv::into_substr_vec(rows.at(3), ',');
+  REQUIRE(row3.size() == 9);
+
+  SECTION("Floating number parsing")
   {
-    auto [a0, b0] = mtgo::csv::str_to_floats("0.72;0.1");
-    INFO("a0: " << a0.value_or(-1.0f));
-    INFO("b0: " << b0.value_or(-1.0f));
-    REQUIRE(a0.has_value());
-    REQUIRE(b0.has_value());
-    CHECK(a0.value() == 0.72f);
-    CHECK(b0.value() == 0.1f);
+    SECTION("Row 1")
+    {
+      auto [a0, b0] = mtgo::csv::str_to_floats(row1.at(6));
+      CHECK(a0.has_value());
+      CHECK(b0.has_value());
+      CHECK(a0.value() == 0.72f);
+      CHECK(b0.value() == 0.1f);
 
-    auto [a01, b01] = mtgo::csv::str_to_floats("0.002;12.1");
-    CHECK(a01.has_value());
-    CHECK(b01.has_value());
-    CHECK(a01.value() == 0.002f);
-    CHECK(b01.value() == 12.1f);
+      auto [a1, b1] = mtgo::csv::str_to_floats(row1.at(7));
+      CHECK(a1.has_value());
+      CHECK_FALSE(b1.has_value());
+      CHECK(a1.value() == 0.78f);
 
-    auto [a1, b1] = mtgo::csv::str_to_floats("0.72;-");
-    CHECK(a1.has_value());
-    CHECK_FALSE(b1.has_value());
-    CHECK(a1.value() == 0.72f);
+      auto [a2, b2] = mtgo::csv::str_to_floats(row1.at(8));
+      CHECK(a2.has_value());
+      CHECK(b2.has_value());
+      CHECK(a2.value() == 0.4f);
+      CHECK(b2.value() == 0.3f);
+    }
 
-    auto [a2, b2] = mtgo::csv::str_to_floats("-;0.1");
-    CHECK_FALSE(a2.has_value());
-    CHECK(b2.has_value());
-    CHECK(b2.value() == 0.1f);
-
-    auto [a3, b3] = mtgo::csv::str_to_floats("-;-");
-    CHECK_FALSE(a3.has_value());
-    CHECK_FALSE(b3.has_value());
-
-    // With more than two values
-    auto [a4, b4] = mtgo::csv::str_to_floats("0.72;0.1;0.2");
-    CHECK(a4.has_value());
-    CHECK(b4.has_value());
-    CHECK(a4.value() == 0.72f);
-    CHECK(b4.value() == 0.1f);
-
-    // With integer values
-    auto [a5, b5] = mtgo::csv::str_to_floats("1;2");
-    CHECK(a5.has_value());
-    CHECK(b5.has_value());
-    CHECK(a5.value() == 1.0f);
-    CHECK(b5.value() == 2.0f);
+    SECTION("Row 2")
+    {
+      for (std::size_t i = 6; i < 9; ++i) {
+        auto [a, b] = mtgo::csv::str_to_floats(row2.at(i));
+        if (i == 6) {
+          CHECK(a.has_value());
+          CHECK(b.has_value());
+          CHECK(a.value() == 1.1f);
+          CHECK(b.value() == 0.9f);
+        } else if (i == 7) {
+          CHECK(a.has_value());
+          CHECK(b.has_value());
+          CHECK(a.value() == 2.0f);
+          CHECK(b.value() == 2.1f);
+        } else if (i == 8) {
+          CHECK(a.has_value());
+          CHECK_FALSE(b.has_value());
+          CHECK(a.value() == 0.9f);
+        }
+      }
+    }
   }
 }
 

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -278,19 +278,12 @@ TEST_CASE("mtgo::csv::floats_from_span")
 
     INFO("csv_str formatted before adding floats:\n" << csv_str);
 
-    for (const auto &[q, gb, b] : q_gb_sc) {
+    for (const auto &[q, gb, sc] : q_gb_sc) {
 
       std::string quantity = q.has_value() ? fmt::format("[{}]", q.value()) : "";
-
-      if (gb.has_value() && b.has_value()) {
-        csv_str += fmt::format(",{}{};{}", quantity, gb.value(), b.value());
-      } else if (gb.has_value()) {
-        csv_str += fmt::format(",{}{};-", quantity, gb.value());
-      } else if (b.has_value()) {
-        csv_str += fmt::format(",{}-;{}", quantity, b.value());
-      } else {
-        csv_str += ",-;-";
-      }
+      std::string gb_str = gb.has_value() ? fmt::format("{}", gb.value()) : "-";
+      std::string b_str = sc.has_value() ? fmt::format("{}", sc.value()) : "-";
+      csv_str += fmt::format(",{}{};{}", quantity, gb_str, b_str);
     }
 
     INFO("csv_str formatting complete with floats added:\n" << csv_str);

--- a/wmake.ps1
+++ b/wmake.ps1
@@ -165,7 +165,8 @@ function Test-Mtgoparser {
             "test_json_parse.exe",
             "test_xml_parse.exe",
             "test_full_collection_parse.exe",
-            "tests.exe"
+            "tests.exe",
+            "test_csv_parse.exe"
         )
 
         foreach ($testSuite in $testSuites) {


### PR DESCRIPTION
First jab at #81 

Using CSV instead of JSON.

Adds the `CardHistory` struct for serializing/deserializing an aggregated price history CSV format looking e.g. like this:

```csv
id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
120020,4,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
101898,2,Dream Trawler,THR,R,false,-;-,[2]2;2.1,[0]0.9;-;
```

The format is defined as follows:
- The fixed headers/columns are `id, quantity, name, set, rarity, foil,` followed by the first ISO 8601 timestamp from when the tradelist was added and price data retrieved for the first time.
- Each time price data is updated, a new column is added with the appropriate timestamp.
- Each field in a timestamp column may be prefixed with `[#]` which signifies the quantity of the card. It only appears if the quantity of the card has changed.
- Missing price data is marked as `-`.
- Price data for a given timestamp consists of the price at Goatbots, semi-colon (`;`) separated with the price at Cardhoarder. _More vendors can be added later following the semi-colon separated pattern._
- The first time a card appears in the user's collection, it is added to the CSV with the quantity of the card in the user's collection. Any dates with price data already in the CSV before the card first appeared, the prices are filled in with `-;-` signifying unavailable price data.
