### PR TITLE
Aggregate price history

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ MTGO Collection Manager
 [![mtgoparser-ci](https://github.com/CramBL/mtgo-collection-manager/actions/workflows/mtgoparser-ci.yml/badge.svg)](https://github.com/CramBL/mtgo-collection-manager/actions/workflows/mtgoparser-ci.yml)
 [![mtgoupdater-ci](https://github.com/CramBL/mtgo-collection-manager/actions/workflows/mtgoupdater-ci.yml/badge.svg)](https://github.com/CramBL/mtgo-collection-manager/actions/workflows/mtgoupdater-ci.yml)
 
+[![CodeFactor](https://www.codefactor.io/repository/github/crambl/mtgo-collection-manager/badge)](https://www.codefactor.io/repository/github/crambl/mtgo-collection-manager)
+
 ## Purpose
 To automate some tasks regarding effective management of [MTGO](https://www.mtgo.com/en/mtgo) collection, that are too cumbersome for anyone to actually do them manually.
 

--- a/mtgoparser/include/mtgoparser/goatbots.hpp
+++ b/mtgoparser/include/mtgoparser/goatbots.hpp
@@ -39,7 +39,7 @@ struct [[nodiscard]] CardDefinition
   [[nodiscard]] inline constexpr bool operator!=(const CardDefinition &other) const { return !(*this == other); }
 };
 
-using price_hist_map_t = boost::unordered_flat_map<uint32_t, double>;
+using price_hist_map_t = boost::unordered_flat_map<uint32_t, float>;
 using card_defs_map_t = boost::unordered_flat_map<uint32_t, CardDefinition>;
 
 template<class T>

--- a/mtgoparser/include/mtgoparser/io.hpp
+++ b/mtgoparser/include/mtgoparser/io.hpp
@@ -228,8 +228,8 @@ struct [[nodiscard]] FileWithTimestamp
 };
 
 /**
- * @brief Get a list of files with an underscord followed by an ISO 8601 timestamp as suffix in a directory sorted by age (oldest first).
- * The timestamp is in the format %Y-%m-%dT%H%M%SZ without sub-second precision.
+ * @brief Get a list of files with an underscord followed by an ISO 8601 timestamp as suffix in a directory sorted by
+ * age (oldest first). The timestamp is in the format %Y-%m-%dT%H%M%SZ without sub-second precision.
  *
  * @param dir_path The path to the directory
  *
@@ -252,7 +252,8 @@ struct [[nodiscard]] FileWithTimestamp
         std::string timestamp = fname.substr(fname.find_last_of('_') + 1);
 
         // Add the file to the vector
-        files_with_timestamp.emplace_back(FileWithTimestamp{ .fpath_ = entry.path(), .timestamp_ = std::move(timestamp) });
+        files_with_timestamp.emplace_back(
+          FileWithTimestamp{ .fpath_ = entry.path(), .timestamp_ = std::move(timestamp) });
       }
     }
   }

--- a/mtgoparser/include/mtgoparser/mtg.hpp
+++ b/mtgoparser/include/mtgoparser/mtg.hpp
@@ -71,7 +71,7 @@ namespace util {
    *
    * @return std::string representation of the Rarity enum.
    */
-  template<rarity_formatter Format> constexpr auto inline rarity_to_string(Rarity rarity) -> std::string
+  template<rarity_formatter Format> auto inline rarity_to_string(Rarity rarity) -> std::string
   {
 
     // Aliases for slightly more readability.

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -150,7 +150,7 @@ void inline Collection::ExtractScryfallInfo(std::vector<scryfall::Card> &&scryfa
     if (c.foil_) { continue; }
     if (c.id_ == 1) [[unlikely]] {
       // Event ticket
-      c.scryfall_price_ = 1.0;
+      c.scryfall_price_ = 1.0f;
       continue;
     }
 

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -157,7 +157,7 @@ void inline Collection::ExtractScryfallInfo(std::vector<scryfall::Card> &&scryfa
     while (scry_it != scry_end && (*scry_it).mtgo_id <= c.id_) {
       if ((*scry_it).mtgo_id == c.id_ && (*scry_it).prices.tix.has_value()
           && (!(*scry_it).prices.tix.value().empty())) {
-        c.scryfall_price_ = std::stod((*scry_it).prices.tix.value());
+        c.scryfall_price_ = std::stof((*scry_it).prices.tix.value());
       }
       ++scry_it;
     }

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -92,7 +92,7 @@ public:
   [[nodiscard]] inline constexpr bool operator!=(const Collection &other) const { return !(*this == other); }
 
   // Begin/end iterators
-  [[nodiscard]] inline auto TakeCards() noexcept -> std::vector<Card>&& { return std::move(this->cards_); }
+  [[nodiscard]] inline auto TakeCards() noexcept -> std::vector<Card> && { return std::move(this->cards_); }
 
 private:
   // Helpers

--- a/mtgoparser/include/mtgoparser/mtgo.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo.hpp
@@ -91,6 +91,9 @@ public:
   [[nodiscard]] inline constexpr bool operator==(const Collection &other) const { return this->cards_ == other.cards_; }
   [[nodiscard]] inline constexpr bool operator!=(const Collection &other) const { return !(*this == other); }
 
+  // Begin/end iterators
+  [[nodiscard]] inline auto TakeCards() noexcept -> std::vector<Card>&& { return std::move(this->cards_); }
+
 private:
   // Helpers
 };

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -35,7 +35,7 @@ struct [[nodiscard]] Card
     std::string set = "",
     std::string rarity = "C",
     bool foil = false,
-    float goatbots_price = 0,
+    float goatbots_price = 0.0f,
     std::optional<float> scryfall_price = {}) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ std::move(name) }, set_{ std::move(set) },
       rarity_{ mtg::util::rarity_from_t(std::move(rarity)) }, foil_{ foil }, goatbots_price_{ goatbots_price },
@@ -49,7 +49,7 @@ struct [[nodiscard]] Card
     const char *set = "",
     const char *rarity = "C",
     bool foil = false,
-    float goatbots_price = 0,
+    float goatbots_price = 0.0f,
     std::optional<float> scryfall_price = {}) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ mtg::util::rarity_from_t(rarity) },
       foil_{ foil }, goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
@@ -63,7 +63,7 @@ struct [[nodiscard]] Card
     std::string_view set,
     std::string_view rarity,
     bool foil = false,
-    float goatbots_price = 0,
+    float goatbots_price = 0.0f,
     std::optional<float> scryfall_price = {}) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ mtg::util::rarity_from_t(rarity) },
       foil_{ foil }, goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
@@ -78,7 +78,7 @@ struct [[nodiscard]] Card
     S set,
     S rarity,
     bool foil = false,
-    float goatbots_price = 0,
+    float goatbots_price = 0.0f,
     std::optional<float> scryfall_price = {}) noexcept
     : id_{ boost::implicit_cast<uint32_t>(id) }, quantity_{ boost::implicit_cast<uint16_t>(quantity) }, name_{ name },
       set_{ set }, rarity_{ mtg::util::rarity_from_t(rarity) }, foil_{ foil }, goatbots_price_{ goatbots_price },

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -71,7 +71,7 @@ struct [[nodiscard]] Card
 
   // Templated constructor
   template<typename I, typename Q, typename S>
-    requires std::convertible_to<I, uint32_t> && std::convertible_to<Q, uint16_t> && std::convertible_to<S, std::string>
+  requires std::convertible_to<I, uint32_t> && std::convertible_to<Q, uint16_t> && std::convertible_to<S, std::string>
   explicit Card(I id,
     Q quantity,
     S name,

--- a/mtgoparser/include/mtgoparser/mtgo/card.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card.hpp
@@ -23,8 +23,8 @@ struct [[nodiscard]] Card
   std::string set_;
   mtg::Rarity rarity_;
   bool foil_;
-  double goatbots_price_;
-  std::optional<double> scryfall_price_;
+  float goatbots_price_;
+  std::optional<float> scryfall_price_;
 
 
   // Default constructor
@@ -35,8 +35,8 @@ struct [[nodiscard]] Card
     std::string set = "",
     std::string rarity = "C",
     bool foil = false,
-    double goatbots_price = 0,
-    std::optional<double> scryfall_price = {}) noexcept
+    float goatbots_price = 0,
+    std::optional<float> scryfall_price = {}) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ std::move(name) }, set_{ std::move(set) },
       rarity_{ mtg::util::rarity_from_t(std::move(rarity)) }, foil_{ foil }, goatbots_price_{ goatbots_price },
       scryfall_price_{ scryfall_price }
@@ -49,8 +49,8 @@ struct [[nodiscard]] Card
     const char *set = "",
     const char *rarity = "C",
     bool foil = false,
-    double goatbots_price = 0,
-    std::optional<double> scryfall_price = {}) noexcept
+    float goatbots_price = 0,
+    std::optional<float> scryfall_price = {}) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ mtg::util::rarity_from_t(rarity) },
       foil_{ foil }, goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
   {}
@@ -63,23 +63,23 @@ struct [[nodiscard]] Card
     std::string_view set,
     std::string_view rarity,
     bool foil = false,
-    double goatbots_price = 0,
-    std::optional<double> scryfall_price = {}) noexcept
+    float goatbots_price = 0,
+    std::optional<float> scryfall_price = {}) noexcept
     : id_{ id }, quantity_{ quantity }, name_{ name }, set_{ set }, rarity_{ mtg::util::rarity_from_t(rarity) },
       foil_{ foil }, goatbots_price_{ goatbots_price }, scryfall_price_{ scryfall_price }
   {}
 
   // Templated constructor
   template<typename I, typename Q, typename S>
-  requires std::convertible_to<I, uint32_t> && std::convertible_to<Q, uint16_t> && std::convertible_to<S, std::string>
+    requires std::convertible_to<I, uint32_t> && std::convertible_to<Q, uint16_t> && std::convertible_to<S, std::string>
   explicit Card(I id,
     Q quantity,
     S name,
     S set,
     S rarity,
     bool foil = false,
-    double goatbots_price = 0,
-    std::optional<double> scryfall_price = {}) noexcept
+    float goatbots_price = 0,
+    std::optional<float> scryfall_price = {}) noexcept
     : id_{ boost::implicit_cast<uint32_t>(id) }, quantity_{ boost::implicit_cast<uint16_t>(quantity) }, name_{ name },
       set_{ set }, rarity_{ mtg::util::rarity_from_t(rarity) }, foil_{ foil }, goatbots_price_{ goatbots_price },
       scryfall_price_{ scryfall_price }

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -1,5 +1,6 @@
 
 #include "mtgoparser/mtg.hpp"
+#include "mtgoparser/mtgo/card.hpp"
 
 #include <array>
 #include <cstdint>
@@ -38,7 +39,7 @@ struct [[nodiscard]] CardHistory
   bool foil_;
   std::vector<tup_quant_and_prices_t> price_history_;
 
-  explicit CardHistory(uint32_t id,
+  [[nodiscard]] explicit CardHistory(uint32_t id,
     QuantityNameSet &&qns,
     mtg::Rarity rarity,
     bool foil,
@@ -46,6 +47,20 @@ struct [[nodiscard]] CardHistory
     : id_(id), quantity_(qns.quantity_), name_(std::move(qns.name_)), set_(std::move(qns.set_)), rarity_(rarity),
       foil_(foil), price_history_(std::move(price_history))
   {}
+
+  // Constructor from mtgo::Card with no unavailable price history
+  [[nodiscard]] explicit CardHistory(mtgo::Card && card) noexcept
+    : id_(card.id_), quantity_(std::to_string(card.quantity_)), name_(std::move(card.name_)), set_(std::move(card.set_)),
+      rarity_(card.rarity_), foil_(card.foil_), price_history_(std::vector<tup_quant_and_prices_t>{std::make_tuple(opt_uint_t{ card.quantity_ }, opt_float_t{ card.goatbots_price_ }, card.scryfall_price_)})
+  {
+  }
+
+  // Constructor from mtgo::Card with unavailable price history
+  [[nodiscard]] explicit CardHistory(mtgo::Card && card, std::vector<tup_quant_and_prices_t> &&price_history) noexcept
+    : id_(card.id_), quantity_(std::to_string(card.quantity_)), name_(std::move(card.name_)), set_(std::move(card.set_)),
+      rarity_(card.rarity_), foil_(card.foil_), price_history_(std::move(price_history))
+  {
+  }
 
   // Move constructor
   [[nodiscard]] CardHistory(CardHistory &&other) noexcept
@@ -82,6 +97,18 @@ struct [[nodiscard]] CardHistory
   }
 
   return csv_row;
+}
+
+[[nodiscard]] inline auto card_history_with_prev_unavailable(mtgo::Card&& card, std::size_t num_prev_timestamps) noexcept -> mtgo::CardHistory
+{
+  std::vector<tup_quant_and_prices_t> price_history;
+  price_history.reserve(num_prev_timestamps+1);
+  for (std::size_t i = 0; i < num_prev_timestamps; ++i) {
+    price_history.emplace_back(std::make_tuple(std::nullopt, std::nullopt, std::nullopt));
+  }
+  // Add the available prices
+  price_history.emplace_back(std::make_tuple(opt_uint_t{ card.quantity_ }, opt_float_t{ card.goatbots_price_ }, card.scryfall_price_));
+  return CardHistory{ std::move(card), std::move(price_history) };
 }
 
 }// namespace mtgo

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -49,18 +49,18 @@ struct [[nodiscard]] CardHistory
   {}
 
   // Constructor from mtgo::Card with no unavailable price history
-  [[nodiscard]] explicit CardHistory(mtgo::Card && card) noexcept
-    : id_(card.id_), quantity_(std::to_string(card.quantity_)), name_(std::move(card.name_)), set_(std::move(card.set_)),
-      rarity_(card.rarity_), foil_(card.foil_), price_history_(std::vector<tup_quant_and_prices_t>{std::make_tuple(opt_uint_t{ card.quantity_ }, opt_float_t{ card.goatbots_price_ }, card.scryfall_price_)})
-  {
-  }
+  [[nodiscard]] explicit CardHistory(mtgo::Card &&card) noexcept
+    : id_(card.id_), quantity_(std::to_string(card.quantity_)), name_(std::move(card.name_)),
+      set_(std::move(card.set_)), rarity_(card.rarity_), foil_(card.foil_),
+      price_history_(std::vector<tup_quant_and_prices_t>{
+        std::make_tuple(opt_uint_t{ card.quantity_ }, opt_float_t{ card.goatbots_price_ }, card.scryfall_price_) })
+  {}
 
   // Constructor from mtgo::Card with unavailable price history
-  [[nodiscard]] explicit CardHistory(mtgo::Card && card, std::vector<tup_quant_and_prices_t> &&price_history) noexcept
-    : id_(card.id_), quantity_(std::to_string(card.quantity_)), name_(std::move(card.name_)), set_(std::move(card.set_)),
-      rarity_(card.rarity_), foil_(card.foil_), price_history_(std::move(price_history))
-  {
-  }
+  [[nodiscard]] explicit CardHistory(mtgo::Card &&card, std::vector<tup_quant_and_prices_t> &&price_history) noexcept
+    : id_(card.id_), quantity_(std::to_string(card.quantity_)), name_(std::move(card.name_)),
+      set_(std::move(card.set_)), rarity_(card.rarity_), foil_(card.foil_), price_history_(std::move(price_history))
+  {}
 
   // Move constructor
   [[nodiscard]] CardHistory(CardHistory &&other) noexcept
@@ -99,15 +99,17 @@ struct [[nodiscard]] CardHistory
   return csv_row;
 }
 
-[[nodiscard]] inline auto card_history_with_prev_unavailable(mtgo::Card&& card, std::size_t num_prev_timestamps) noexcept -> mtgo::CardHistory
+[[nodiscard]] inline auto card_history_with_prev_unavailable(mtgo::Card &&card,
+  std::size_t num_prev_timestamps) noexcept -> mtgo::CardHistory
 {
   std::vector<tup_quant_and_prices_t> price_history;
-  price_history.reserve(num_prev_timestamps+1);
+  price_history.reserve(num_prev_timestamps + 1);
   for (std::size_t i = 0; i < num_prev_timestamps; ++i) {
     price_history.emplace_back(std::make_tuple(std::nullopt, std::nullopt, std::nullopt));
   }
   // Add the available prices
-  price_history.emplace_back(std::make_tuple(opt_uint_t{ card.quantity_ }, opt_float_t{ card.goatbots_price_ }, card.scryfall_price_));
+  price_history.emplace_back(
+    std::make_tuple(opt_uint_t{ card.quantity_ }, opt_float_t{ card.goatbots_price_ }, card.scryfall_price_));
   return CardHistory{ std::move(card), std::move(price_history) };
 }
 

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -78,6 +78,15 @@ struct [[nodiscard]] CardHistory
       rarity_(other.rarity_), foil_(other.foil_), price_history_(std::move(other.price_history_))
   {}
 
+  // Comparison operator
+  [[nodiscard]] inline bool operator==(const CardHistory &other) const noexcept
+  {
+    return id_ == other.id_ && quantity_ == other.quantity_ && name_ == other.name_ && set_ == other.set_ &&
+      rarity_ == other.rarity_ && foil_ == other.foil_ && price_history_ == other.price_history_;
+  }
+
+  [[nodiscard]] inline bool operator!=(const CardHistory &other) const noexcept { return !(*this == other); }
+
   // Delete copy && assignment constructor
   CardHistory(const CardHistory &) = delete;
   CardHistory &operator=(const CardHistory &) = delete;

--- a/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/card_history.hpp
@@ -81,8 +81,8 @@ struct [[nodiscard]] CardHistory
   // Comparison operator
   [[nodiscard]] inline bool operator==(const CardHistory &other) const noexcept
   {
-    return id_ == other.id_ && quantity_ == other.quantity_ && name_ == other.name_ && set_ == other.set_ &&
-      rarity_ == other.rarity_ && foil_ == other.foil_ && price_history_ == other.price_history_;
+    return id_ == other.id_ && quantity_ == other.quantity_ && name_ == other.name_ && set_ == other.set_
+           && rarity_ == other.rarity_ && foil_ == other.foil_ && price_history_ == other.price_history_;
   }
 
   [[nodiscard]] inline bool operator!=(const CardHistory &other) const noexcept { return !(*this == other); }

--- a/mtgoparser/include/mtgoparser/mtgo/history_aggregator.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/history_aggregator.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+// Adds collections together to form an aggregate collection with a history of prices etc.
+// Saves the aggregate as CSV
+
+/* The collection data JSON files are named e.g. like this:
+    mtgo-cards_2023-11-08T200010Z.json
+   And contains a JSON array of mtgo::Card objects.
+
+   The steps to aggregate the collections are:
+    1. Read JSON files in order of date (oldest first)
+    2. Aggregate the collections in a collection aggregate class (define an add function for the class)
+       - Add goatbots price history and scryfall price history to the aggregate
+       - When adding a card to the aggregate, if the card already exists in the aggregate, update the
+         card's price history with the new price history
+       - If the card does not exist in the aggregate, add it to the aggregate
+    3. Save the aggregate as a CSV file
+    4. Zip all the aggregate CSV files into a single zip file
+*/
+
+#include "mtgoparser/mtgo/card_history.hpp"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace mtgo {
+
+  struct [[nodiscard]] CardHistoryAggregate {
+    mtgo::CardHistory card_history_;
+    // The newest quantity is the last time the quantity changed
+    // Used to determine if the history should include a quantity update
+    uint16_t newest_quantity_;
+  };
+
+class CollectionHistory
+{
+
+  std::vector<std::string> timestamps_;
+  std::vector<CardHistoryAggregate> card_histories_;
+
+public:
+  [[nodiscard]] explicit CollectionHistory() = default;
+
+  [[nodiscard]] explicit CollectionHistory(std::vector<mtgo::CardHistory> &&card_histories, std::string&& timestamp) noexcept
+  {
+    for (auto &&card_history : card_histories) {
+      uint16_t newest_quantity = 0;
+      for (auto [quantity, price, foil_price] : card_history.price_history_) {
+        if (quantity.has_value()) {
+          newest_quantity = quantity.value();
+        }
+      }
+      this->card_histories_.emplace_back(CardHistoryAggregate{ .card_history_{std::move(card_history)},
+                                                               .newest_quantity_ = newest_quantity });
+    }
+    this->timestamps_.emplace_back(std::move(timestamp));
+  }
+
+  void addCollectionPriceHistory(mtgo::Collection&& collection, std::string&& timestamp) {
+
+    auto cards = collection.TakeCards();
+
+    for (auto &&card : cards) {
+      auto it = std::find_if(this->card_histories_.begin(), this->card_histories_.end(), [&](const auto &card_hist) {
+        return card_hist.card_history_.id_ == card.id_;
+      });
+
+      if (it != card_histories_.end()) {
+        if (card.quantity_ != it->newest_quantity_)
+        {
+          it->newest_quantity_ = card.quantity_;
+          it->card_history_.price_history_.emplace_back(std::make_tuple(card.quantity_, card.goatbots_price_, card.scryfall_price_));
+        } else {
+          // Quantity has not changed, but price history should still be added
+          it->card_history_.price_history_.emplace_back(std::make_tuple(std::nullopt, card.goatbots_price_, card.scryfall_price_));
+        }
+      } else {
+        // Add the card history
+        this->card_histories_.emplace_back(
+          CardHistoryAggregate{ .card_history_{ card_history_with_prev_unavailable(std::move(card), this->timestamps_.size()) },
+                                                                 .newest_quantity_ = card.quantity_ });
+      }
+    }
+    this->timestamps_.emplace_back(std::move(timestamp));
+  }
+
+  [[nodiscard]] inline auto Size() const noexcept -> std::size_t { return card_histories_.size(); }
+
+  [[nodiscard]] inline auto ToCsvStr() noexcept -> std::string {
+    std::string csv_str;
+    static constexpr std::size_t prealloc_10_mib = 1024 * 1024 * 10;
+    csv_str.reserve(prealloc_10_mib);
+
+    // Write the header
+    csv_str += "id,quantity,name,set,rarity,foil";
+    for (auto &&timestamp : this->timestamps_) {
+      csv_str += ',' + timestamp;
+    }
+
+    // Write the card histories
+    for (auto &&card_hist : this->card_histories_) {
+      csv_str += '\n';
+      csv_str += card_history_to_csv_row(std::move(card_hist.card_history_));
+    }
+
+    return csv_str;
+  }
+
+};
+
+}// namespace mtgo

--- a/mtgoparser/include/mtgoparser/mtgo/history_aggregator.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/history_aggregator.hpp
@@ -23,6 +23,9 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include <string>
+#include <fstream>
+#include <filesystem>
 
 namespace mtgo {
 
@@ -106,6 +109,23 @@ public:
     }
 
     return csv_str;
+  }
+
+  /**
+   * @brief Saves the collection history as a CSV file with the newest timestamp as suffix.
+   *
+   * @note `fpath` is modified to include the newest timestamp as suffix.
+   *
+   * @param fpath The path to the CSV file to add the timestamp to and then save.
+   */
+  inline void SaveAsCsvWithTimestamp(std::filesystem::path& fpath) noexcept
+  {
+    // Add the the newest timestamp to the filename as suffix
+    fpath.replace_filename(fpath.filename().string() + '_' + this->timestamps_.back() + ".csv" );
+
+    // Save the CSV file
+    std::ofstream csv_file(fpath);
+    csv_file << this->ToCsvStr();
   }
 };
 

--- a/mtgoparser/include/mtgoparser/mtgo/history_aggregator.hpp
+++ b/mtgoparser/include/mtgoparser/mtgo/history_aggregator.hpp
@@ -37,6 +37,17 @@ struct [[nodiscard]] CardHistoryAggregate
   // The newest quantity is the last time the quantity changed
   // Used to determine if the history should include a quantity update
   uint16_t newest_quantity_;
+
+  // Equality operators
+  [[nodiscard]] inline auto operator==(const CardHistoryAggregate &other) const noexcept -> bool
+  {
+    return this->card_history_ == other.card_history_ && this->newest_quantity_ == other.newest_quantity_;
+  }
+
+  [[nodiscard]] inline auto operator!=(const CardHistoryAggregate &other) const noexcept -> bool
+  {
+    return !(*this == other);
+  }
 };
 
 class CollectionHistory
@@ -99,6 +110,11 @@ public:
 
   [[nodiscard]] inline auto Size() const noexcept -> std::size_t { return card_histories_.size(); }
 
+  /**
+   * @brief Consumes/moves the CardHistory vector and returns the collection history as a CSV string.
+   *
+   * @return std::string The collection history as a CSV string.
+   */
   [[nodiscard]] inline auto ToCsvStr() noexcept -> std::string
   {
     std::string csv_str;
@@ -133,6 +149,17 @@ public:
     // Save the CSV file
     std::ofstream csv_file(fpath);
     csv_file << this->ToCsvStr();
+  }
+
+  // Comparison operators
+  [[nodiscard]] inline auto operator==(const CollectionHistory &other) const noexcept -> bool
+  {
+    return this->timestamps_ == other.timestamps_ && this->card_histories_ == other.card_histories_;
+  }
+
+  [[nodiscard]] inline auto operator!=(const CollectionHistory &other) const noexcept -> bool
+  {
+    return !(*this == other);
   }
 };
 

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -5,6 +5,7 @@
 
 #include <fmt/core.h>
 
+#include <mtgoparser/mtgo/history_aggregator.hpp>
 #include <mtgoparser/mtgo/card_history.hpp>
 #include <mtgoparser/mtgo/csv.hpp>
 
@@ -15,22 +16,22 @@
 
 using Catch::Matchers::ContainsSubstring;
 
+const std::string global_test_csv_data =
+    R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
+120020,1,"In the Darkness Bind Them",LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
+106729,1,"Razorverge Thicket",ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
+106729,1,"Razorverge Thicket",THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
+
 
 TEST_CASE("mtgo::csv::into_substr_vec")
 {
-  const std::string test_csv_data =
-    R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
-120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
-
-  std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+  std::vector<std::string> rows = mtgo::csv::into_lines_vec(global_test_csv_data);
   REQUIRE(rows.size() == 4);
 
   CHECK(rows.at(0) == "id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z");
-  CHECK(rows.at(1) == "120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3");
-  CHECK(rows.at(2) == "106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-");
-  CHECK(rows.at(3) == "106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-");
+  CHECK(rows.at(1) == "120020,1,\"In the Darkness Bind Them\",LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3");
+  CHECK(rows.at(2) == "106729,1,\"Razorverge Thicket\",ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-");
+  CHECK(rows.at(3) == "106729,1,\"Razorverge Thicket\",THR,R,false,-;-,[2]2;2.1,[0]0.9;-");
 
 
   auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
@@ -115,13 +116,8 @@ TEST_CASE("mtgo::csv::str_to_floats")
 
 TEST_CASE("mtgo::csv::into_substr_vec & mtgo::csv::str_to_floats")
 {
-  const std::string test_csv_data =
-    R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
-120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
 
-  std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+  std::vector<std::string> rows = mtgo::csv::into_lines_vec(global_test_csv_data);
   REQUIRE(rows.size() == 4);
 
   auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
@@ -207,13 +203,8 @@ TEST_CASE("mtgo::csv::floats_from_span")
 
   SECTION("On CSV Data with mtgo::csv::into_substr_vec")
   {
-    const std::string test_csv_data =
-      R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
-120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
 
-    std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+    std::vector<std::string> rows = mtgo::csv::into_lines_vec(global_test_csv_data);
     REQUIRE(rows.size() == 4);
     auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
     REQUIRE(headers.size() == 9);
@@ -246,11 +237,11 @@ TEST_CASE("mtgo::csv::floats_from_span")
 
   SECTION("Parse CSV into row data and back into CSV string")
   {
-    const std::string test_csv_data =
+    const std::string local_test_csv_data =
       R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
-120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3)";
+120020,1,"In the Darkness Bind Them",LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3)";
 
-    std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+    std::vector<std::string> rows = mtgo::csv::into_lines_vec(local_test_csv_data);
     REQUIRE(rows.size() == 2);
     auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
     REQUIRE(headers.size() == 9);
@@ -259,6 +250,8 @@ TEST_CASE("mtgo::csv::floats_from_span")
 
     auto q_gb_sc = mtgo::csv::quant_and_prices_from_span(std::span(row1).subspan(6));
     REQUIRE(q_gb_sc.size() == 3);
+
+    std::string card_name = '\"' + row1.at(2) + '\"'; // Should be quoted
 
     std::string csv_str = fmt::format("{},{},{},{},{},{},{},{},{}\n{},{},{},{},{},{}",
       headers.at(0),
@@ -272,7 +265,7 @@ TEST_CASE("mtgo::csv::floats_from_span")
       headers.at(8),
       row1.at(0),
       row1.at(1),
-      row1.at(2),
+      card_name,
       row1.at(3),
       row1.at(4),
       row1.at(5));
@@ -289,16 +282,16 @@ TEST_CASE("mtgo::csv::floats_from_span")
 
     INFO("csv_str formatting complete with floats added:\n" << csv_str);
 
-    CHECK(csv_str == test_csv_data);
+    CHECK(csv_str == local_test_csv_data);
   }
 
   SECTION("Parse CSV into mtgo::CardHistory")
   {
-    const std::string test_csv_data =
+    const std::string local_test_csv_data =
       R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
-120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3)";
+120020,1,"In the Darkness Bind Them",LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3)";
 
-    std::vector<std::string> rows = mtgo::csv::into_substr_vec(test_csv_data, '\n');
+    std::vector<std::string> rows = mtgo::csv::into_lines_vec(local_test_csv_data);
     REQUIRE(rows.size() == 2);
     auto headers = mtgo::csv::into_substr_vec(rows[0], ',');
     REQUIRE(headers.size() == 9);
@@ -346,13 +339,7 @@ TEST_CASE("mtgo::csv::floats_from_span")
     using mtgo::card_history_to_csv_row;
     using util::sv_to_uint;
 
-    const std::string test_csv_data =
-      R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
-120020,1,In the Darkness Bind Them,LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
-106729,1,Razorverge Thicket,ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
-106729,1,Razorverge Thicket,THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
-
-    std::vector<std::string> rows = into_substr_vec(test_csv_data, '\n');
+    std::vector<std::string> rows = mtgo::csv::into_lines_vec(global_test_csv_data);
     REQUIRE(rows.size() == 4);
 
     auto headers = into_substr_vec(rows[0], ',');
@@ -430,9 +417,60 @@ TEST_CASE("mtgo::csv::floats_from_span")
       serialized_csv += csv_row3;
 
       INFO("serialized_csv:\n" << serialized_csv);
-      CHECK(serialized_csv == test_csv_data);
+      CHECK(serialized_csv == global_test_csv_data);
     }
   }
+}
+
+TEST_CASE("CSV-data to CardHistory & CollectionHistory")
+{
+  const std::string local_test_csv_data =
+      R"(id,quantity,name,set,rarity,foil,2023-11-06T083944Z,2023-11-06T115147Z,2023-11-08T084732Z
+120020,1,"In the Darkness Bind Them",LTC,R,false,[4]0.72;0.1,[8]0.78;-,0.4;0.3
+106729,1,"Razorverge Thicket",ONE,R,false,[1]1.1;0.9,2;2.1,[11]0.9;-
+106729,1,"Haktos the Unscarred",THR,R,false,-;-,[2]2;2.1,[0]0.9;-)";
+
+  SECTION("mtgo::csv_row_to_card_history")
+    {
+      auto rows = mtgo::csv::into_lines_vec(local_test_csv_data);
+
+      auto card_hist1 = mtgo::csv_row_to_card_history(std::move(rows.at(1)));
+      CHECK(card_hist1.id_ == 120020);
+      CHECK(card_hist1.quantity_ == "1");
+      CHECK(card_hist1.name_ == "In the Darkness Bind Them");
+      CHECK(card_hist1.set_ == "LTC");
+      CHECK(card_hist1.rarity_ == mtg::Rarity::Rare);
+      CHECK(card_hist1.foil_ == false);
+      CHECK(card_hist1.price_history_.size() == 3);
+
+      auto card_hist2 = mtgo::csv_row_to_card_history(std::move(rows.at(2)));
+      CHECK(card_hist2.id_ == 106729);
+      CHECK(card_hist2.quantity_ == "1");
+      CHECK(card_hist2.name_ == "Razorverge Thicket");
+      CHECK(card_hist2.set_ == "ONE");
+      CHECK(card_hist2.rarity_ == mtg::Rarity::Rare);
+      CHECK(card_hist2.foil_ == false);
+      CHECK(card_hist2.price_history_.size() == 3);
+
+      auto card_hist3 = mtgo::csv_row_to_card_history(std::move(rows.at(3)));
+      CHECK(card_hist3.id_ == 106729);
+      CHECK(card_hist3.quantity_ == "1");
+      CHECK(card_hist3.name_ == "Haktos the Unscarred");
+      CHECK(card_hist3.set_ == "THR");
+      CHECK(card_hist3.rarity_ == mtg::Rarity::Rare);
+      CHECK(card_hist3.foil_ == false);
+      CHECK(card_hist3.price_history_.size() == 3);
+
+      SECTION("mtgo::csv_to_collection_history")
+      {
+        std::string csv_to_hist_string = local_test_csv_data; // Copy the test data
+        auto collection_history = mtgo::csv_to_collection_history(std::move(csv_to_hist_string));
+
+        CHECK(collection_history.Size() == 3);
+
+      }
+
+    }
 }
 
 // NOLINTEND

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -462,50 +462,49 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
     CHECK(card_hist3.price_history_.size() == 3);
   }
 
+  SECTION("mtgo::csv_to_collection_history")
+  {
+    auto rows = mtgo::csv::into_lines_vec(local_test_csv_data);
+
+    std::string row_1_copy = rows.at(1);
+    mtgo::CardHistory card_hist1 = mtgo::csv_row_to_card_history(std::move(rows.at(1)));
+    CHECK(card_hist1.id_ == 120020);
+    CHECK(card_hist1.quantity_ == "1");
+    CHECK(card_hist1.name_ == "In the Darkness Bind Them");
+    CHECK(card_hist1.set_ == "LTC");
+    CHECK(card_hist1.rarity_ == mtg::Rarity::Rare);
+    CHECK(card_hist1.foil_ == false);
+    CHECK(card_hist1.price_history_.size() == 3);
+    auto card_hist_1_copy = mtgo::csv_row_to_card_history(std::move(row_1_copy));
+    CHECK(card_hist1 == card_hist_1_copy);// Test equality operator
+
+    auto card_hist2 = mtgo::csv_row_to_card_history(std::move(rows.at(2)));
+    CHECK(card_hist2.id_ == 106729);
+    CHECK(card_hist2.quantity_ == "1");
+    CHECK(card_hist2.name_ == "Razorverge Thicket");
+    CHECK(card_hist2.set_ == "ONE");
+    CHECK(card_hist2.rarity_ == mtg::Rarity::Rare);
+    CHECK(card_hist2.foil_ == false);
+    CHECK(card_hist2.price_history_.size() == 3);
+    CHECK(card_hist2 != card_hist1);// Test inequality operator
+
+    auto card_hist3 = mtgo::csv_row_to_card_history(std::move(rows.at(3)));
+    CHECK(card_hist3.id_ == 106729);
+    CHECK(card_hist3.quantity_ == "1");
+    CHECK(card_hist3.name_ == "Haktos the Unscarred");
+    CHECK(card_hist3.set_ == "THR");
+    CHECK(card_hist3.rarity_ == mtg::Rarity::Rare);
+    CHECK(card_hist3.foil_ == false);
+    CHECK(card_hist3.price_history_.size() == 3);
+
     SECTION("mtgo::csv_to_collection_history")
     {
-      auto rows = mtgo::csv::into_lines_vec(local_test_csv_data);
+      std::string csv_to_hist_string = local_test_csv_data;// Copy the test data
+      auto collection_history = mtgo::csv_to_collection_history(std::move(csv_to_hist_string));
 
-      std::string row_1_copy = rows.at(1);
-      mtgo::CardHistory card_hist1 = mtgo::csv_row_to_card_history(std::move(rows.at(1)));
-      CHECK(card_hist1.id_ == 120020);
-      CHECK(card_hist1.quantity_ == "1");
-      CHECK(card_hist1.name_ == "In the Darkness Bind Them");
-      CHECK(card_hist1.set_ == "LTC");
-      CHECK(card_hist1.rarity_ == mtg::Rarity::Rare);
-      CHECK(card_hist1.foil_ == false);
-      CHECK(card_hist1.price_history_.size() == 3);
-      auto card_hist_1_copy = mtgo::csv_row_to_card_history(std::move(row_1_copy));
-      CHECK(card_hist1 == card_hist_1_copy);// Test equality operator
-
-      auto card_hist2 = mtgo::csv_row_to_card_history(std::move(rows.at(2)));
-      CHECK(card_hist2.id_ == 106729);
-      CHECK(card_hist2.quantity_ == "1");
-      CHECK(card_hist2.name_ == "Razorverge Thicket");
-      CHECK(card_hist2.set_ == "ONE");
-      CHECK(card_hist2.rarity_ == mtg::Rarity::Rare);
-      CHECK(card_hist2.foil_ == false);
-      CHECK(card_hist2.price_history_.size() == 3);
-      CHECK(card_hist2 != card_hist1);// Test inequality operator
-
-      auto card_hist3 = mtgo::csv_row_to_card_history(std::move(rows.at(3)));
-      CHECK(card_hist3.id_ == 106729);
-      CHECK(card_hist3.quantity_ == "1");
-      CHECK(card_hist3.name_ == "Haktos the Unscarred");
-      CHECK(card_hist3.set_ == "THR");
-      CHECK(card_hist3.rarity_ == mtg::Rarity::Rare);
-      CHECK(card_hist3.foil_ == false);
-      CHECK(card_hist3.price_history_.size() == 3);
-
-      SECTION("mtgo::csv_to_collection_history")
-      {
-        std::string csv_to_hist_string = local_test_csv_data;// Copy the test data
-        auto collection_history = mtgo::csv_to_collection_history(std::move(csv_to_hist_string));
-
-        CHECK(collection_history.Size() == 3);
-      }
+      CHECK(collection_history.Size() == 3);
     }
-
+  }
 }
 
 // NOLINTEND

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -460,6 +460,7 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
     CHECK(card_hist3.rarity_ == mtg::Rarity::Rare);
     CHECK(card_hist3.foil_ == false);
     CHECK(card_hist3.price_history_.size() == 3);
+  }
 
     SECTION("mtgo::csv_to_collection_history")
     {
@@ -503,10 +504,8 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
 
         CHECK(collection_history.Size() == 3);
       }
-
-      CHECK(collection_history.Size() == 3);
     }
-  }
+
 }
 
 // NOLINTEND

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -434,7 +434,8 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
     {
       auto rows = mtgo::csv::into_lines_vec(local_test_csv_data);
 
-      auto card_hist1 = mtgo::csv_row_to_card_history(std::move(rows.at(1)));
+      std::string row_1_copy = rows.at(1);
+      mtgo::CardHistory card_hist1 = mtgo::csv_row_to_card_history(std::move(rows.at(1)));
       CHECK(card_hist1.id_ == 120020);
       CHECK(card_hist1.quantity_ == "1");
       CHECK(card_hist1.name_ == "In the Darkness Bind Them");
@@ -442,6 +443,8 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
       CHECK(card_hist1.rarity_ == mtg::Rarity::Rare);
       CHECK(card_hist1.foil_ == false);
       CHECK(card_hist1.price_history_.size() == 3);
+      auto card_hist_1_copy = mtgo::csv_row_to_card_history(std::move(row_1_copy));
+      CHECK(card_hist1 == card_hist_1_copy); // Test equality operator
 
       auto card_hist2 = mtgo::csv_row_to_card_history(std::move(rows.at(2)));
       CHECK(card_hist2.id_ == 106729);
@@ -451,6 +454,7 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
       CHECK(card_hist2.rarity_ == mtg::Rarity::Rare);
       CHECK(card_hist2.foil_ == false);
       CHECK(card_hist2.price_history_.size() == 3);
+      CHECK(card_hist2 != card_hist1); // Test inequality operator
 
       auto card_hist3 = mtgo::csv_row_to_card_history(std::move(rows.at(3)));
       CHECK(card_hist3.id_ == 106729);

--- a/mtgoparser/test/test_csv_parse.cpp
+++ b/mtgoparser/test/test_csv_parse.cpp
@@ -475,7 +475,7 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
       CHECK(card_hist1.foil_ == false);
       CHECK(card_hist1.price_history_.size() == 3);
       auto card_hist_1_copy = mtgo::csv_row_to_card_history(std::move(row_1_copy));
-      CHECK(card_hist1 == card_hist_1_copy); // Test equality operator
+      CHECK(card_hist1 == card_hist_1_copy);// Test equality operator
 
       auto card_hist2 = mtgo::csv_row_to_card_history(std::move(rows.at(2)));
       CHECK(card_hist2.id_ == 106729);
@@ -485,7 +485,7 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
       CHECK(card_hist2.rarity_ == mtg::Rarity::Rare);
       CHECK(card_hist2.foil_ == false);
       CHECK(card_hist2.price_history_.size() == 3);
-      CHECK(card_hist2 != card_hist1); // Test inequality operator
+      CHECK(card_hist2 != card_hist1);// Test inequality operator
 
       auto card_hist3 = mtgo::csv_row_to_card_history(std::move(rows.at(3)));
       CHECK(card_hist3.id_ == 106729);
@@ -498,11 +498,10 @@ TEST_CASE("CSV-data to CardHistory & CollectionHistory")
 
       SECTION("mtgo::csv_to_collection_history")
       {
-        std::string csv_to_hist_string = local_test_csv_data; // Copy the test data
+        std::string csv_to_hist_string = local_test_csv_data;// Copy the test data
         auto collection_history = mtgo::csv_to_collection_history(std::move(csv_to_hist_string));
 
         CHECK(collection_history.Size() == 3);
-
       }
 
       CHECK(collection_history.Size() == 3);

--- a/mtgoparser/test/test_full_collection_parse.cpp
+++ b/mtgoparser/test/test_full_collection_parse.cpp
@@ -12,9 +12,15 @@ using Catch::Matchers::ContainsSubstring;
 #include "mtgoparser/goatbots.hpp"
 #include "mtgoparser/mtgo.hpp"
 #include "mtgoparser/scryfall.hpp"
+#include "mtgoparser/io.hpp"
+#include "mtgoparser/mtgo/history_aggregator.hpp"
+
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
+#include <fstream>
+#include <filesystem>
 
 // Used by the first section (small collection)
 // Goes to top of project and into the shared 'test/test-data' directory
@@ -93,7 +99,88 @@ TEST_CASE("Parse small collection")
     mtgo_collection.PrettyPrint();
 
     auto pretty_json_str = mtgo_collection.ToJsonPretty();
-    CHECK(mtgo_collection == mtgo::Collection(pretty_json_str));
+    REQUIRE(mtgo_collection == mtgo::Collection(pretty_json_str));
+
+    SECTION("Aggregate price history")
+    {
+      // Save the same collection to JSON twice with different timestamps
+      // Then aggregate the two collections
+      auto json_str = mtgo_collection.ToJson();
+      auto json_str2 = mtgo_collection.ToJson();
+
+      // Save to files
+      const std::string fname {"mtgo_cards_2023-11-05T152700Z"};
+      const std::string fname2{"mtgo_cards_2023-11-05T152800Z"};
+
+      const std::string sub_dir{ "collection-history-full-collection-parse" };
+      std::filesystem::create_directory(sub_dir);
+
+      const std::filesystem::path fpath{ sub_dir + "/" + fname };
+      const std::filesystem::path fpath2{ sub_dir + "/" + fname2 };
+      INFO("Saving files to: " << fpath.string() << " and " << fpath2.string());
+      INFO("Files extensions: " << fpath.extension().string() << " and " << fpath2.extension().string());
+
+      {
+        std::ofstream test_file(fpath);
+        test_file << json_str;
+        std::ofstream test_file2(fpath2);
+        test_file2 << json_str2;
+      }
+
+      INFO("Saved files to: " << fpath.string() << " and " << fpath2.string());
+
+
+      // Get the files with timestamps
+      auto json_files = io_util::get_files_with_timestamp(sub_dir);
+      INFO("Got files with timestamps: " << json_files[0].fpath_.string() << " and " << json_files[1].fpath_.string());
+      CHECK(json_files[0].timestamp_ == "2023-11-05T152700Z");
+      CHECK(json_files[1].timestamp_ == "2023-11-05T152800Z");
+
+      // Take a copy of the most recent timestamp for the CSV-file suffix
+      auto last_timestamp = json_files.at(1).timestamp_;
+
+      // Deserialize the files
+      auto new_json_str = io_util::read_to_str_buf(json_files[0].fpath_);
+      auto new_json_str2 = io_util::read_to_str_buf(json_files[1].fpath_);
+
+      // Deserialize the collections
+      auto new_collection = mtgo::Collection(new_json_str);
+      auto new_collection2 = mtgo::Collection(new_json_str2);
+      CHECK(new_collection.Size() == 3000);
+      CHECK(new_collection2.Size() == 3000);
+
+      // Aggregate the collections
+      auto cards = new_collection.TakeCards();
+
+      // Transform the vector to a vector of CardHistory
+      std::vector<mtgo::CardHistory> card_histories;
+      card_histories.reserve(cards.size());
+      for (auto &&card : cards) { card_histories.emplace_back(std::move(card)); }
+      CHECK(card_histories.size() == 3000);
+
+      auto collection_history = mtgo::CollectionHistory(std::move(card_histories), std::move(json_files[0].timestamp_));
+      CHECK(collection_history.Size() == 3000);
+
+      // Add the second collection to the aggregate
+      collection_history.addCollectionPriceHistory(std::move(new_collection2), std::move(json_files[1].timestamp_));
+      CHECK(collection_history.Size() == 3000);
+
+      // Save the aggregate to a CSV file
+      const std::string csv_fname{ "mtgo_cards_csv_" + last_timestamp + ".csv"};
+      const std::filesystem::path csv_fpath{ sub_dir + "/" + csv_fname };
+      INFO("Saving CSV file to: " << csv_fpath.string());
+
+      {
+        std::ofstream csv_file(csv_fpath);
+        auto csv_string = collection_history.ToCsvStr();
+        INFO("CSV string: " << csv_string);
+        csv_file << collection_history.ToCsvStr();
+        fmt::println("CSV string:\n{}", csv_string);
+      }
+
+      // Clean up by removing the files and directory
+      std::filesystem::remove_all(sub_dir);
+    }
   }
 }
 

--- a/mtgoparser/test/test_full_collection_parse.cpp
+++ b/mtgoparser/test/test_full_collection_parse.cpp
@@ -9,11 +9,11 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 using Catch::Matchers::ContainsSubstring;
 
-#include "mtgoparser/goatbots.hpp"
-#include "mtgoparser/io.hpp"
-#include "mtgoparser/mtgo.hpp"
-#include "mtgoparser/mtgo/history_aggregator.hpp"
-#include "mtgoparser/scryfall.hpp"
+#include <mtgoparser/goatbots.hpp>
+#include <mtgoparser/io.hpp>
+#include <mtgoparser/mtgo.hpp>
+#include <mtgoparser/scryfall.hpp>
+#include <mtgoparser/mtgo/history_aggregator.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -56,9 +56,9 @@ TEST_CASE("Parse small collection")
     REQUIRE(mtgo_collection.Size() == 5);
 
     mtgo_collection.ExtractGoatbotsInfo(card_defs.value(), price_hist.value());
-    mtgo_collection.PrettyPrint();
+    // mtgo_collection.PrettyPrint();
     mtgo_collection.ExtractScryfallInfo(std::move(scryfall_vec.value()));
-    mtgo_collection.PrettyPrint();
+    // mtgo_collection.PrettyPrint();
 
     CHECK(mtgo_collection.TotalCards() == 457);
 
@@ -96,7 +96,7 @@ TEST_CASE("Parse small collection")
 
     mtgo_collection.ExtractGoatbotsInfo(card_defs.value(), price_hist.value());
     mtgo_collection.ExtractScryfallInfo(std::move(scryfall_vec.value()));
-    mtgo_collection.PrettyPrint();
+    // mtgo_collection.PrettyPrint();
 
     auto pretty_json_str = mtgo_collection.ToJsonPretty();
     REQUIRE(mtgo_collection == mtgo::Collection(pretty_json_str));
@@ -175,7 +175,7 @@ TEST_CASE("Parse small collection")
         auto csv_string = collection_history.ToCsvStr();
         INFO("CSV string: " << csv_string);
         csv_file << collection_history.ToCsvStr();
-        fmt::println("CSV string:\n{}", csv_string);
+        // fmt::println("CSV string:\n{}", csv_string);
       }
 
       // Clean up by removing the files and directory
@@ -196,6 +196,14 @@ TEST_CASE("Parse small collection")
         INFO("CSV file name: " << new_csv_fpath.filename().string());
         CHECK(new_csv_fpath.filename().string() == "mtgo_cards_2023-11-05T152800Z.csv");
         CHECK(new_csv_fpath.extension().string() == ".csv");
+
+        SECTION("mtgo::csv_to_collection_history")
+        {
+          // Parse the CSV file back into a CollectionHistory
+          auto csv_str = io_util::read_to_str_buf(new_csv_fpath);
+          auto new_collection_history = mtgo::csv_to_collection_history(std::move(csv_str));
+          //CHECK(new_collection_history.Size() == 3000);
+        }
 
         // Clean up by removing the files and directory
         std::filesystem::remove_all(sub_dir);

--- a/mtgoparser/test/test_full_collection_parse.cpp
+++ b/mtgoparser/test/test_full_collection_parse.cpp
@@ -64,8 +64,91 @@ TEST_CASE("Parse small collection")
 
     auto pretty_json_str = mtgo_collection.ToJsonPretty();
     CHECK(mtgo_collection == mtgo::Collection(pretty_json_str));
-  }
 
+    SECTION("Aggregate price history")
+    {
+      // Save the same collection to JSON twice with different timestamps
+      // Then aggregate the two collections
+      auto json_str = mtgo_collection.ToJson();
+      auto json_str2 = mtgo_collection.ToJson();
+
+      // Save to files
+      const std::string fname{ "mtgo_cards_2023-11-05T152700Z" };
+      const std::string fname2{ "mtgo_cards_2023-11-05T152800Z" };
+
+      const std::string sub_dir{ "collection-history-small-collection-parse" };
+      std::filesystem::create_directory(sub_dir);
+
+      const std::filesystem::path fpath{ sub_dir + "/" + fname };
+      const std::filesystem::path fpath2{ sub_dir + "/" + fname2 };
+      INFO("Saving files to: " << fpath.string() << " and " << fpath2.string());
+      INFO("Files extensions: " << fpath.extension().string() << " and " << fpath2.extension().string());
+
+      {
+        std::ofstream test_file(fpath);
+        test_file << json_str;
+        std::ofstream test_file2(fpath2);
+        test_file2 << json_str2;
+      }
+
+      INFO("Saved files to: " << fpath.string() << " and " << fpath2.string());
+
+      // Get the files with timestamps
+      auto json_files = io_util::get_files_with_timestamp(sub_dir);
+      INFO("Got files with timestamps: " << json_files[0].fpath_.string() << " and " << json_files[1].fpath_.string());
+      CHECK(json_files[0].timestamp_ == "2023-11-05T152700Z");
+      CHECK(json_files[1].timestamp_ == "2023-11-05T152800Z");
+
+      // Take a copy of the most recent timestamp for the CSV-file suffix
+      auto last_timestamp = json_files.at(1).timestamp_;
+
+      // Deserialize the files
+      auto new_json_str = io_util::read_to_str_buf(json_files[0].fpath_);
+      auto new_json_str2 = io_util::read_to_str_buf(json_files[1].fpath_);
+
+      // Deserialize the collections
+      auto new_collection = mtgo::Collection(new_json_str);
+      auto new_collection2 = mtgo::Collection(new_json_str2);
+      CHECK(new_collection.Size() == 5);
+      CHECK(new_collection2.Size() == 5);
+
+      // Aggregate the collections
+      auto cards = new_collection.TakeCards();
+
+      // Transform the vector to a vector of CardHistory
+      std::vector<mtgo::CardHistory> card_histories;
+      card_histories.reserve(cards.size());
+      for (auto &&card : cards) { card_histories.emplace_back(std::move(card)); }
+      CHECK(card_histories.size() == 5);
+
+      auto collection_history = mtgo::CollectionHistory(std::move(card_histories), std::move(json_files[0].timestamp_));
+      CHECK(collection_history.Size() == 5);
+
+      // Add the second collection to the aggregate
+      collection_history.addCollectionPriceHistory(std::move(new_collection2), std::move(json_files[1].timestamp_));
+      CHECK(collection_history.Size() == 5);
+
+      SECTION("mtgo::csv_to_collection_history")
+      {
+
+        std::string to_csv_str = collection_history.ToCsvStr();
+        CHECK( to_csv_str == collection_history.ToCsvStr() );
+
+        // Deserialize the CSV string back into a CollectionHistory
+        auto new_collection_history = mtgo::csv_to_collection_history(std::move(to_csv_str));
+        CHECK(new_collection_history.Size() == 5);
+        CHECK(new_collection_history == collection_history);
+        CHECK(new_collection_history.ToCsvStr() == collection_history.ToCsvStr());
+      }
+      // Clean up by removing the files and directory
+    std::filesystem::remove_all(sub_dir);
+    }
+  }
+}
+
+
+TEST_CASE("Parse medium collection")
+{
   const auto path_mtgogetter_out_scryfall_full = "../../../test/test-data/mtgogetter-out/scryfall-20231002-full.json";
   const auto path_trade_list_medium_3000cards = "../../../test/test-data/mtgo/Full Trade List-medium-3000cards.dek";
   const auto path_goatbots_card_defs_full = "../../../test/test-data/goatbots/card-definitions-2023-10-02-full.json";
@@ -148,6 +231,7 @@ TEST_CASE("Parse small collection")
       auto new_collection2 = mtgo::Collection(new_json_str2);
       CHECK(new_collection.Size() == 3000);
       CHECK(new_collection2.Size() == 3000);
+      CHECK(new_collection == new_collection2);
 
       // Aggregate the collections
       auto cards = new_collection.TakeCards();
@@ -203,7 +287,24 @@ TEST_CASE("Parse small collection")
           // Parse the CSV file back into a CollectionHistory
           auto csv_str = io_util::read_to_str_buf(new_csv_fpath);
           auto new_collection_history = mtgo::csv_to_collection_history(std::move(csv_str));
-          //CHECK(new_collection_history.Size() == 3000);
+          CHECK(new_collection_history.Size() == 3000);
+
+          std::string new_csv_str = new_collection_history.ToCsvStr();
+          CHECK(new_csv_str == new_collection_history.ToCsvStr());
+          std::string old_csv_str = collection_history.ToCsvStr();
+          // Check that making a CSV string doesn't change the CollectionHistory
+          if (new_csv_str != old_csv_str) {
+            // TODO: Figure out why the new string has an extra newline at the end of the header line
+            //        but somehow the old string doesn't, and it only shows up when opening the files in Notepad++
+            auto new_num_newlines = std::count(new_csv_str.begin(), new_csv_str.end(), '\n');
+            auto old_num_newlines = std::count(old_csv_str.begin(), old_csv_str.end(), '\n');
+            CHECK(new_num_newlines == old_num_newlines);
+          }
+
+          // Check that the CSV string is the same as the one we parsed
+          auto new_collection_history2 = mtgo::csv_to_collection_history(std::move(new_csv_str));
+          CHECK(new_collection_history2 == new_collection_history);
+          CHECK(new_collection_history2.ToCsvStr() == new_collection_history.ToCsvStr());
         }
 
         // Clean up by removing the files and directory

--- a/mtgoparser/test/test_full_collection_parse.cpp
+++ b/mtgoparser/test/test_full_collection_parse.cpp
@@ -10,17 +10,17 @@
 using Catch::Matchers::ContainsSubstring;
 
 #include "mtgoparser/goatbots.hpp"
-#include "mtgoparser/mtgo.hpp"
-#include "mtgoparser/scryfall.hpp"
 #include "mtgoparser/io.hpp"
+#include "mtgoparser/mtgo.hpp"
 #include "mtgoparser/mtgo/history_aggregator.hpp"
+#include "mtgoparser/scryfall.hpp"
 
+#include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-#include <fstream>
-#include <filesystem>
 
 // Used by the first section (small collection)
 // Goes to top of project and into the shared 'test/test-data' directory
@@ -109,8 +109,8 @@ TEST_CASE("Parse small collection")
       auto json_str2 = mtgo_collection.ToJson();
 
       // Save to files
-      const std::string fname {"mtgo_cards_2023-11-05T152700Z"};
-      const std::string fname2{"mtgo_cards_2023-11-05T152800Z"};
+      const std::string fname{ "mtgo_cards_2023-11-05T152700Z" };
+      const std::string fname2{ "mtgo_cards_2023-11-05T152800Z" };
 
       const std::string sub_dir{ "collection-history-full-collection-parse" };
       std::filesystem::create_directory(sub_dir);
@@ -166,7 +166,7 @@ TEST_CASE("Parse small collection")
       CHECK(collection_history.Size() == 3000);
 
       // Save the aggregate to a CSV file
-      const std::string csv_fname{ "mtgo_cards_csv_" + last_timestamp + ".csv"};
+      const std::string csv_fname{ "mtgo_cards_csv_" + last_timestamp + ".csv" };
       const std::filesystem::path csv_fpath{ sub_dir + "/" + csv_fname };
       INFO("Saving CSV file to: " << csv_fpath.string());
 

--- a/mtgoparser/test/test_full_collection_parse.cpp
+++ b/mtgoparser/test/test_full_collection_parse.cpp
@@ -180,6 +180,27 @@ TEST_CASE("Parse small collection")
 
       // Clean up by removing the files and directory
       std::filesystem::remove_all(sub_dir);
+
+      SECTION("mtgo::CardAggregator::SaveAsCsvWithTimestamp")
+      {
+        // Create the sub_dir again and do the last steps but with the mtgo::CardAggregator::SaveAsCsvWithTimestamp member function
+        std::filesystem::create_directory(sub_dir);
+        const std::string new_csv_fname{ "mtgo_cards" };
+        std::filesystem::path new_csv_fpath{ sub_dir + "/" + new_csv_fname };
+        INFO("Saving CSV file to: " << new_csv_fpath.string());
+
+        collection_history.SaveAsCsvWithTimestamp(new_csv_fpath);
+        CHECK(std::filesystem::exists(new_csv_fpath));
+
+        // Check that the filename has the correct timestamp suffix
+        INFO("CSV file name: " << new_csv_fpath.filename().string());
+        CHECK(new_csv_fpath.filename().string() == "mtgo_cards_2023-11-05T152800Z.csv");
+        CHECK(new_csv_fpath.extension().string() == ".csv");
+
+        // Clean up by removing the files and directory
+        std::filesystem::remove_all(sub_dir);
+
+      }
     }
   }
 }

--- a/mtgoparser/test/test_full_collection_parse.cpp
+++ b/mtgoparser/test/test_full_collection_parse.cpp
@@ -132,7 +132,7 @@ TEST_CASE("Parse small collection")
       {
 
         std::string to_csv_str = collection_history.ToCsvStr();
-        CHECK( to_csv_str == collection_history.ToCsvStr() );
+        CHECK(to_csv_str == collection_history.ToCsvStr());
 
         // Deserialize the CSV string back into a CollectionHistory
         auto new_collection_history = mtgo::csv_to_collection_history(std::move(to_csv_str));
@@ -141,7 +141,7 @@ TEST_CASE("Parse small collection")
         CHECK(new_collection_history.ToCsvStr() == collection_history.ToCsvStr());
       }
       // Clean up by removing the files and directory
-    std::filesystem::remove_all(sub_dir);
+      std::filesystem::remove_all(sub_dir);
     }
   }
 }

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -743,126 +743,125 @@ TEST_CASE("io_util::is_files_equal")
 
 TEST_CASE("io_util::get_files_with_timestamp")
 {
-  SECTION("2 files year differs") {
-    // Create two files with different timestamps
-  const std::string newer_timestamp{ "2023-11-14T113236Z" };
-  const std::string older_timestamp{ "2022-11-14T113236Z" };
-  const std::string newer{ "mtgo-cards_" + newer_timestamp };
-  const std::string older{ "mtgo-cards_" + older_timestamp };
-  const std::string sub_dir{ "collection-history" };
-
-  std::filesystem::create_directory(sub_dir);
-
-  // Paths to the files
-  const std::filesystem::path newer_path = sub_dir + "/" + newer;
-  const std::filesystem::path older_path = sub_dir + "/" + older;
-
-  // Save the files
+  SECTION("2 files year differs")
   {
-    std::ofstream test_fileA(newer_path);
-    std::ofstream test_fileB(older_path);
-  }
-
-  // Get the files sorted by timestamp
-  auto files = io_util::get_files_with_timestamp(sub_dir);
-  CHECK(files.at(0).fpath_ == older_path);
-  CHECK(files.at(0).timestamp_ == older_timestamp);
-  CHECK(files.at(1).fpath_ == newer_path);
-  CHECK(files.at(1).timestamp_ == newer_timestamp);
-
-  // Clean up by removing the files and directory
-  std::filesystem::remove_all(sub_dir);
-
-  }
-
-  SECTION("2 files - day and time differs") {
     // Create two files with different timestamps
-  const std::string newer_timestamp{ "2023-11-17T075106Z" };
-  const std::string older_timestamp{ "2023-11-14T113236Z" };
-  const std::string newer{ "mtgo-cards_" + newer_timestamp };
-  const std::string older{ "mtgo-cards_" + older_timestamp };
-  const std::string sub_dir{ "collection-history" };
+    const std::string newer_timestamp{ "2023-11-14T113236Z" };
+    const std::string older_timestamp{ "2022-11-14T113236Z" };
+    const std::string newer{ "mtgo-cards_" + newer_timestamp };
+    const std::string older{ "mtgo-cards_" + older_timestamp };
+    const std::string sub_dir{ "collection-history" };
 
-  std::filesystem::create_directory(sub_dir);
+    std::filesystem::create_directory(sub_dir);
 
-  // Paths to the files
-  const std::filesystem::path newer_path = sub_dir + "/" + newer;
-  const std::filesystem::path older_path = sub_dir + "/" + older;
+    // Paths to the files
+    const std::filesystem::path newer_path = sub_dir + "/" + newer;
+    const std::filesystem::path older_path = sub_dir + "/" + older;
 
-  // Save the files
+    // Save the files
+    {
+      std::ofstream test_fileA(newer_path);
+      std::ofstream test_fileB(older_path);
+    }
+
+    // Get the files sorted by timestamp
+    auto files = io_util::get_files_with_timestamp(sub_dir);
+    CHECK(files.at(0).fpath_ == older_path);
+    CHECK(files.at(0).timestamp_ == older_timestamp);
+    CHECK(files.at(1).fpath_ == newer_path);
+    CHECK(files.at(1).timestamp_ == newer_timestamp);
+
+    // Clean up by removing the files and directory
+    std::filesystem::remove_all(sub_dir);
+  }
+
+  SECTION("2 files - day and time differs")
   {
-    std::ofstream test_fileA(newer_path);
-    std::ofstream test_fileB(older_path);
-  }
-
-  // Get the files sorted by timestamp
-  auto files = io_util::get_files_with_timestamp(sub_dir);
-  CHECK(files.at(0).fpath_ == older_path);
-  CHECK(files.at(0).timestamp_ == older_timestamp);
-  CHECK(files.at(1).fpath_ == newer_path);
-  CHECK(files.at(1).timestamp_ == newer_timestamp);
-
-  // Clean up by removing the files and directory
-  std::filesystem::remove_all(sub_dir);
-
-  }
-
-  SECTION("5 files - all different") {
     // Create two files with different timestamps
-  const std::string oldest_timestamp{ "2022-11-05T075106Z" };
-  const std::string second_timestamp{ "2023-01-00T003236Z" };
-  const std::string third_timestamp{ "2023-09-14T113236Z" };
-  const std::string fourth_timestamp{ "2023-11-14T113236Z" };
-  const std::string fifth_timestamp{ "2023-11-14T123236Z" };
-  const std::string oldest{ "mtgo-cards_" + oldest_timestamp };
-  const std::string second{ "mtgo-cards_" + second_timestamp };
-  const std::string third{ "mtgo-cards_" + third_timestamp };
-  const std::string fourth{ "mtgo-cards_" + fourth_timestamp };
-  const std::string fifth{ "mtgo-cards_" + fifth_timestamp };
-  const std::string sub_dir{ "collection-history" };
+    const std::string newer_timestamp{ "2023-11-17T075106Z" };
+    const std::string older_timestamp{ "2023-11-14T113236Z" };
+    const std::string newer{ "mtgo-cards_" + newer_timestamp };
+    const std::string older{ "mtgo-cards_" + older_timestamp };
+    const std::string sub_dir{ "collection-history" };
 
-  std::filesystem::create_directory(sub_dir);
+    std::filesystem::create_directory(sub_dir);
 
-  // Paths to the files
-  const std::filesystem::path oldest_path = sub_dir + "/" + oldest;
-  const std::filesystem::path second_path = sub_dir + "/" + second;
-  const std::filesystem::path third_path = sub_dir + "/" + third;
-  const std::filesystem::path fourth_path = sub_dir + "/" + fourth;
-  const std::filesystem::path fifth_path = sub_dir + "/" + fifth;
+    // Paths to the files
+    const std::filesystem::path newer_path = sub_dir + "/" + newer;
+    const std::filesystem::path older_path = sub_dir + "/" + older;
 
-  // Save the files
+    // Save the files
+    {
+      std::ofstream test_fileA(newer_path);
+      std::ofstream test_fileB(older_path);
+    }
+
+    // Get the files sorted by timestamp
+    auto files = io_util::get_files_with_timestamp(sub_dir);
+    CHECK(files.at(0).fpath_ == older_path);
+    CHECK(files.at(0).timestamp_ == older_timestamp);
+    CHECK(files.at(1).fpath_ == newer_path);
+    CHECK(files.at(1).timestamp_ == newer_timestamp);
+
+    // Clean up by removing the files and directory
+    std::filesystem::remove_all(sub_dir);
+  }
+
+  SECTION("5 files - all different")
   {
-    std::ofstream file_oldest(oldest_path);
-    std::ofstream file_second(second_path);
-    std::ofstream file_third(third_path);
-    std::ofstream file_fourth(fourth_path);
-    std::ofstream file_fifth(fifth_path);
+    // Create two files with different timestamps
+    const std::string oldest_timestamp{ "2022-11-05T075106Z" };
+    const std::string second_timestamp{ "2023-01-00T003236Z" };
+    const std::string third_timestamp{ "2023-09-14T113236Z" };
+    const std::string fourth_timestamp{ "2023-11-14T113236Z" };
+    const std::string fifth_timestamp{ "2023-11-14T123236Z" };
+    const std::string oldest{ "mtgo-cards_" + oldest_timestamp };
+    const std::string second{ "mtgo-cards_" + second_timestamp };
+    const std::string third{ "mtgo-cards_" + third_timestamp };
+    const std::string fourth{ "mtgo-cards_" + fourth_timestamp };
+    const std::string fifth{ "mtgo-cards_" + fifth_timestamp };
+    const std::string sub_dir{ "collection-history" };
+
+    std::filesystem::create_directory(sub_dir);
+
+    // Paths to the files
+    const std::filesystem::path oldest_path = sub_dir + "/" + oldest;
+    const std::filesystem::path second_path = sub_dir + "/" + second;
+    const std::filesystem::path third_path = sub_dir + "/" + third;
+    const std::filesystem::path fourth_path = sub_dir + "/" + fourth;
+    const std::filesystem::path fifth_path = sub_dir + "/" + fifth;
+
+    // Save the files
+    {
+      std::ofstream file_oldest(oldest_path);
+      std::ofstream file_second(second_path);
+      std::ofstream file_third(third_path);
+      std::ofstream file_fourth(fourth_path);
+      std::ofstream file_fifth(fifth_path);
+    }
+
+    // Get the files sorted by timestamp
+    auto files = io_util::get_files_with_timestamp(sub_dir);
+
+    CHECK(files.at(0).fpath_ == oldest_path);
+    CHECK(files.at(0).timestamp_ == oldest_timestamp);
+
+    CHECK(files.at(1).fpath_ == second_path);
+    CHECK(files.at(1).timestamp_ == second_timestamp);
+
+    CHECK(files.at(2).fpath_ == third_path);
+    CHECK(files.at(2).timestamp_ == third_timestamp);
+
+    CHECK(files.at(3).fpath_ == fourth_path);
+    CHECK(files.at(3).timestamp_ == fourth_timestamp);
+
+    CHECK(files.at(4).fpath_ == fifth_path);
+    CHECK(files.at(4).timestamp_ == fifth_timestamp);
+
+
+    // Clean up by removing the files and directory
+    std::filesystem::remove_all(sub_dir);
   }
-
-  // Get the files sorted by timestamp
-  auto files = io_util::get_files_with_timestamp(sub_dir);
-
-  CHECK(files.at(0).fpath_ == oldest_path);
-  CHECK(files.at(0).timestamp_ == oldest_timestamp);
-
-  CHECK(files.at(1).fpath_ == second_path);
-  CHECK(files.at(1).timestamp_ == second_timestamp);
-
-  CHECK(files.at(2).fpath_ == third_path);
-  CHECK(files.at(2).timestamp_ == third_timestamp);
-
-  CHECK(files.at(3).fpath_ == fourth_path);
-  CHECK(files.at(3).timestamp_ == fourth_timestamp);
-
-  CHECK(files.at(4).fpath_ == fifth_path);
-  CHECK(files.at(4).timestamp_ == fifth_timestamp);
-
-
-  // Clean up by removing the files and directory
-  std::filesystem::remove_all(sub_dir);
-
-  }
-
 }
 
 // NOLINTEND

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -26,7 +26,6 @@ constinit auto static_clap = clap::Clap<1, 0>(clap::OptionArray<1>(clap::Option(
 
 TEST_CASE("Test basic CLAP")
 {
-
   char argv0[] = "mtgo_preprocessor";
   char argv1[] = "--version";
 
@@ -56,7 +55,6 @@ TEST_CASE("Test basic CLAP")
 
   SECTION("Alias version cmd - Show version")
   {
-
     auto clap_alias_version = clap::Clap<1, 0>(clap::OptionArray<1>(clap::Option("--version", Flag, "-V")));
 
     CHECK(clap_alias_version.Parse(arg_vec) == 0);
@@ -71,7 +69,6 @@ TEST_CASE("Test basic CLAP")
 
 TEST_CASE("Test CLAP with options and values")
 {
-
   char argv0[] = "mtgo_preprocessor";
   char arg_version[] = "--version";
   char arg_save_as[] = "--save-as";
@@ -134,7 +131,6 @@ TEST_CASE("Test CLAP with options and values")
 
 TEST_CASE("MTGO card - Initialize and use of")
 {
-
   SECTION("Initialize")
   {
     // Test constructors, assignments, initializations with different types
@@ -285,7 +281,6 @@ TEST_CASE("Parse state_log.toml")
   // Check goatbots values
   SECTION("Goatbots state_log data")
   {
-
     std::optional<toml::date_time> card_defs_updated_at =
       state_log["goatbots"]["card_definitions_updated_at"].value<toml::date_time>();
     REQUIRE(card_defs_updated_at.has_value());

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -152,7 +152,7 @@ TEST_CASE("MTGO card - Initialize and use of")
 
     unsigned int id2 = 1;
     mtgo::Card mtgo_card2 =
-      mtgo::Card(id2, util::sv_to_uint<uint16_t>("1").value(), "name", "set", "C", true, 1.0, 2.0);
+      mtgo::Card(id2, util::sv_to_uint<uint16_t>("1").value(), "name", "set", "C", true, 1.0f, 2.0f);
     CHECK(mtgo_card2.id_ == 1);
     CHECK(mtgo_card2.quantity_ == 1);
     CHECK(mtgo_card2.name_ == "name");
@@ -197,8 +197,8 @@ TEST_CASE("MTGO card - Initialize and use of")
 
     uint16_t ids = 1;
     uint16_t quantities = 1;
-    mtgo::Card mtgo_card = mtgo::Card(ids, quantities, "name", "set", "common", true, 1.0, 2.0);
-    mtgo::Card mtgo_card2 = mtgo::Card(ids, quantities, "name", "set", "common", true, 1.0, 2.0);
+    mtgo::Card mtgo_card = mtgo::Card(ids, quantities, "name", "set", "common", true, 1.0f, 2.0f);
+    mtgo::Card mtgo_card2 = mtgo::Card(ids, quantities, "name", "set", "common", true, 1.0f, 2.0f);
 
     // Move constructor
     mtgo::Card mtgo_card3(std::move(mtgo_card));
@@ -208,7 +208,7 @@ TEST_CASE("MTGO card - Initialize and use of")
 
     // Move assignment
     uint16_t id_tmp = 2;
-    auto mtgo_card_tmp = mtgo::Card(id_tmp, quantities, "name", "set", "common", true, 1.0, 2.0);
+    auto mtgo_card_tmp = mtgo::Card(id_tmp, quantities, "name", "set", "common", true, 1.0f, 2.0f);
     mtgo_card3 = std::move(mtgo_card_tmp);
     CHECK(mtgo_card3 != mtgo_card2);// ID should differ
     // Check that mtgo_card_tmp is now invalid (commented out as it triggered warning in CI)

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -741,4 +741,128 @@ TEST_CASE("io_util::is_files_equal")
   }
 }
 
+TEST_CASE("io_util::get_files_with_timestamp")
+{
+  SECTION("2 files year differs") {
+    // Create two files with different timestamps
+  const std::string newer_timestamp{ "2023-11-14T113236Z" };
+  const std::string older_timestamp{ "2022-11-14T113236Z" };
+  const std::string newer{ "mtgo-cards_" + newer_timestamp };
+  const std::string older{ "mtgo-cards_" + older_timestamp };
+  const std::string sub_dir{ "collection-history" };
+
+  std::filesystem::create_directory(sub_dir);
+
+  // Paths to the files
+  const std::filesystem::path newer_path = sub_dir + "/" + newer;
+  const std::filesystem::path older_path = sub_dir + "/" + older;
+
+  // Save the files
+  {
+    std::ofstream test_fileA(newer_path);
+    std::ofstream test_fileB(older_path);
+  }
+
+  // Get the files sorted by timestamp
+  auto files = io_util::get_files_with_timestamp(sub_dir);
+  CHECK(files.at(0).fpath_ == older_path);
+  CHECK(files.at(0).timestamp_ == older_timestamp);
+  CHECK(files.at(1).fpath_ == newer_path);
+  CHECK(files.at(1).timestamp_ == newer_timestamp);
+
+  // Clean up by removing the files and directory
+  std::filesystem::remove_all(sub_dir);
+
+  }
+
+  SECTION("2 files - day and time differs") {
+    // Create two files with different timestamps
+  const std::string newer_timestamp{ "2023-11-17T075106Z" };
+  const std::string older_timestamp{ "2023-11-14T113236Z" };
+  const std::string newer{ "mtgo-cards_" + newer_timestamp };
+  const std::string older{ "mtgo-cards_" + older_timestamp };
+  const std::string sub_dir{ "collection-history" };
+
+  std::filesystem::create_directory(sub_dir);
+
+  // Paths to the files
+  const std::filesystem::path newer_path = sub_dir + "/" + newer;
+  const std::filesystem::path older_path = sub_dir + "/" + older;
+
+  // Save the files
+  {
+    std::ofstream test_fileA(newer_path);
+    std::ofstream test_fileB(older_path);
+  }
+
+  // Get the files sorted by timestamp
+  auto files = io_util::get_files_with_timestamp(sub_dir);
+  CHECK(files.at(0).fpath_ == older_path);
+  CHECK(files.at(0).timestamp_ == older_timestamp);
+  CHECK(files.at(1).fpath_ == newer_path);
+  CHECK(files.at(1).timestamp_ == newer_timestamp);
+
+  // Clean up by removing the files and directory
+  std::filesystem::remove_all(sub_dir);
+
+  }
+
+  SECTION("5 files - all different") {
+    // Create two files with different timestamps
+  const std::string oldest_timestamp{ "2022-11-05T075106Z" };
+  const std::string second_timestamp{ "2023-01-00T003236Z" };
+  const std::string third_timestamp{ "2023-09-14T113236Z" };
+  const std::string fourth_timestamp{ "2023-11-14T113236Z" };
+  const std::string fifth_timestamp{ "2023-11-14T123236Z" };
+  const std::string oldest{ "mtgo-cards_" + oldest_timestamp };
+  const std::string second{ "mtgo-cards_" + second_timestamp };
+  const std::string third{ "mtgo-cards_" + third_timestamp };
+  const std::string fourth{ "mtgo-cards_" + fourth_timestamp };
+  const std::string fifth{ "mtgo-cards_" + fifth_timestamp };
+  const std::string sub_dir{ "collection-history" };
+
+  std::filesystem::create_directory(sub_dir);
+
+  // Paths to the files
+  const std::filesystem::path oldest_path = sub_dir + "/" + oldest;
+  const std::filesystem::path second_path = sub_dir + "/" + second;
+  const std::filesystem::path third_path = sub_dir + "/" + third;
+  const std::filesystem::path fourth_path = sub_dir + "/" + fourth;
+  const std::filesystem::path fifth_path = sub_dir + "/" + fifth;
+
+  // Save the files
+  {
+    std::ofstream file_oldest(oldest_path);
+    std::ofstream file_second(second_path);
+    std::ofstream file_third(third_path);
+    std::ofstream file_fourth(fourth_path);
+    std::ofstream file_fifth(fifth_path);
+  }
+
+  // Get the files sorted by timestamp
+  auto files = io_util::get_files_with_timestamp(sub_dir);
+
+  CHECK(files.at(0).fpath_ == oldest_path);
+  CHECK(files.at(0).timestamp_ == oldest_timestamp);
+
+  CHECK(files.at(1).fpath_ == second_path);
+  CHECK(files.at(1).timestamp_ == second_timestamp);
+
+  CHECK(files.at(2).fpath_ == third_path);
+  CHECK(files.at(2).timestamp_ == third_timestamp);
+
+  CHECK(files.at(3).fpath_ == fourth_path);
+  CHECK(files.at(3).timestamp_ == fourth_timestamp);
+
+  CHECK(files.at(4).fpath_ == fifth_path);
+  CHECK(files.at(4).timestamp_ == fifth_timestamp);
+
+
+  // Clean up by removing the files and directory
+  std::filesystem::remove_all(sub_dir);
+
+  }
+
+}
+
 // NOLINTEND

--- a/mtgoparser/test/tests.cpp
+++ b/mtgoparser/test/tests.cpp
@@ -159,9 +159,9 @@ TEST_CASE("MTGO card - Initialize and use of")
     CHECK(mtgo_card2.set_ == "set");
     CHECK(mtgo_card2.rarity_ == mtg::Rarity::Common);
     CHECK(mtgo_card2.foil_ == true);
-    CHECK(mtgo_card2.goatbots_price_ == 1.0);
+    CHECK(mtgo_card2.goatbots_price_ == 1.0f);
     REQUIRE(mtgo_card2.scryfall_price_.has_value());
-    REQUIRE(mtgo_card2.scryfall_price_.value() == 2.0);
+    REQUIRE(mtgo_card2.scryfall_price_.value() == 2.0f);
 
     CHECK(mtgo_card != mtgo_card2);
 

--- a/wmake.ps1
+++ b/wmake.ps1
@@ -68,36 +68,36 @@ function Test-RustInstallation {
 
 
 function Show-Versions {
-    Write-Host "Operating System: $OS_TYPE"
-    Write-Host "Rust : $RUST_VERSION (min. $RUST_MIN_VERSION)"
-    Write-Host "Go   : $GO_VERSION (min. $GO_MIN_VERSION)"
-    Write-Host "C++"
-    Write-Host "  - LLVM: $CLANG_VERSION (min. $LLVM_MIN_VERSION)"
-    Write-Host "  - GCC : $GCC_VERSION (min. $GCC_MIN_VERSION)"
-    Write-Host "CMake: $CMAKE_VERSION (min. $CMAKE_MIN_VERSION)"
-    Write-Host "CMake generator: ${MTGOPARSER_GENERATOR}"
+    Write-Output "Operating System: $OS_TYPE"
+    Write-Output "Rust : $RUST_VERSION (min. $RUST_MIN_VERSION)"
+    Write-Output "Go   : $GO_VERSION (min. $GO_MIN_VERSION)"
+    Write-Output "C++"
+    Write-Output "  - LLVM: $CLANG_VERSION (min. $LLVM_MIN_VERSION)"
+    Write-Output "  - GCC : $GCC_VERSION (min. $GCC_MIN_VERSION)"
+    Write-Output "CMake: $CMAKE_VERSION (min. $CMAKE_MIN_VERSION)"
+    Write-Output "CMake generator: ${MTGOPARSER_GENERATOR}"
     if ($MTGOPARSER_GENERATOR -eq "Ninja Multi-Config") {
         try {
             $NINJA_VERSION = & ninja --version
         } catch {
-            Write-Host "Ninja Multi-Config specified but Ninja not found"
+            Write-Output "Ninja Multi-Config specified but Ninja not found"
             exit 1
         }
-        Write-Host "Ninja: ${NINJA_VERSION}"
+        Write-Output "Ninja: ${NINJA_VERSION}"
     }
 }
 
 function Build-All {
-    Write-Host "----------------------------------"
-    Write-Host "==> Building all targets "
-    Write-Host "----------------------------------"
+    Write-Output "----------------------------------"
+    Write-Output "==> Building all targets "
+    Write-Output "----------------------------------"
     Build-Mtgogetter
     Build-Mtgoparser
     Build-Mtgoupdater
     Build-Mtgogui
-    Write-Host "================================= "
-    Write-Host "=== Done building all targets === "
-    Write-Host "================================= "
+    Write-Output "================================= "
+    Write-Output "=== Done building all targets === "
+    Write-Output "================================= "
 }
 
 # For integration testing, disabling warnings as errors for mtgoparser
@@ -109,21 +109,21 @@ function Build-AllIntegration {
 }
 
 function Test-All {
-    Write-Host "----------------------------------"
-    Write-Host "==> Testing all targets "
-    Write-Host "----------------------------------"
+    Write-Output "----------------------------------"
+    Write-Output "==> Testing all targets "
+    Write-Output "----------------------------------"
     Test-Mtgogetter
     Test-Mtgoparser
     Test-Mtgoupdater
     Test-Mtgogui
-    Write-Host "================================= "
-    Write-Host "=== Done testing all targets === "
-    Write-Host "================================= "
+    Write-Output "================================= "
+    Write-Output "=== Done testing all targets === "
+    Write-Output "================================= "
 }
 
 function Build-Mtgoparser {
     Show-Versions
-    Write-Host "==> Building MTGO Parser..."
+    Write-Output "==> Building MTGO Parser..."
     Set-Location mtgoparser
     cmake -S . -B build -G "${MTGOPARSER_GENERATOR}" -Dmtgoparser_ENABLE_IPO="${MTGOPARSER_IPO}" -DCMAKE_BUILD_TYPE:STRING=${MTGOPARSER_BUILD_MODE} -Dmtgoparser_ENABLE_COVERAGE:BOOL=${MTGOPARSER_ENABLE_COV} -DBOOST_EXCLUDE_LIBRARIES="${MTGOPARSER_EXCLUDE_BOOST_LIBS}" 2>&1
     if ($LASTEXITCODE -ne 0) {
@@ -133,7 +133,7 @@ function Build-Mtgoparser {
         if ($LASTEXITCODE -ne 0) {
             Write-Error "!!! ERROR while building MTGO Parser: code ${LASTEXITCODE}"
         } else {
-            Write-Host "=== Done building MTGO Parser ==="
+            Write-Output "=== Done building MTGO Parser ==="
         }
     }
     Set-Location ..
@@ -142,23 +142,23 @@ function Build-Mtgoparser {
 
 function Build-MtgoparserIntegration {
     Show-Versions
-    Write-Host "==> Building MTGO Parser..."
+    Write-Output "==> Building MTGO Parser..."
     Set-Location mtgoparser
     cmake -S . -B build -G "${MTGOPARSER_GENERATOR}" -Dmtgoparser_DEPLOYING_BINARY=On -Dmtgoparser_ENABLE_IPO="${MTGOPARSER_IPO}" -DCMAKE_BUILD_TYPE:STRING=${MTGOPARSER_BUILD_MODE} -Dmtgoparser_ENABLE_COVERAGE:BOOL=${MTGOPARSER_ENABLE_COV} -Dmtgoparser_WARNINGS_AS_ERRORS:BOOL=OFF -Dmtgoparser_ENABLE_CLANG_TIDY:BOOL=OFF -Dmtgoparser_ENABLE_CPPCHECK:BOOL=OFF -DBOOST_EXCLUDE_LIBRARIES="${MTGOPARSER_EXCLUDE_BOOST_LIBS}"
     cmake --build build --config ${MTGOPARSER_BUILD_MODE}
     Set-Location ..
-    Write-Host "=== Done building MTGO Parser ==="
+    Write-Output "=== Done building MTGO Parser ==="
 }
 
 function Test-Mtgoparser {
     Show-Versions
-    Write-Host "==> Testing MTGO Parser..."
+    Write-Output "==> Testing MTGO Parser..."
     Set-Location mtgoparser\build
     ctest --output-on-failure
 
     if (${LASTEXITCODE} -ne 0) {
         Write-Error "MTGO Parser test failed!"
-        Write-Host "Rerunning each test suite with more details until one fails"
+        Write-Output "Rerunning each test suite with more details until one fails"
         Set-Location test
 
         $testSuites = @(
@@ -179,38 +179,38 @@ function Test-Mtgoparser {
     }
 
     Set-Location -Path $PSScriptRoot
-    Write-Host "=== Done testing MTGO Parser ==="
+    Write-Output "=== Done testing MTGO Parser ==="
 }
 
 function Test-MtgoparserBenchmark {
     Show-Versions
-    Write-Host "==> Running MTGO Parser benchmarks..."
+    Write-Output "==> Running MTGO Parser benchmarks..."
     Set-Location mtgoparser\build\test
     .\Release\benchmark_xml_parse.exe [.]
     Set-Location -Path $PSScriptRoot
-    Write-Host "=== Done running MTGO Parser benchmarks ==="
+    Write-Output "=== Done running MTGO Parser benchmarks ==="
 }
 
 function Build-Mtgogetter {
     Show-Versions
     Test-GoInstallation
-    Write-Host "==> Building MTGO Getter..."
+    Write-Output "==> Building MTGO Getter..."
     go build -C mtgogetter -v
-    Write-Host "=== Done building MTGO Getter ==="
+    Write-Output "=== Done building MTGO Getter ==="
 }
 
 function Test-Mtgogetter {
     Show-Versions
     Test-GoInstallation
-    Write-Host "==> Testing MTGO Getter..."
+    Write-Output "==> Testing MTGO Getter..."
     go test -C mtgogetter -v ./...
-    Write-Host "=== Done testing MTGO Getter ==="
+    Write-Output "=== Done testing MTGO Getter ==="
 }
 
 function Build-Mtgoupdater {
     Show-Versions
     Test-RustInstallation
-    Write-Host "==> Building MTGO Updater..."
+    Write-Output "==> Building MTGO Updater..."
     Set-Location mtgoupdater
     if ($BUILD_MODE -icontains "release") {
         cargo build -r
@@ -218,23 +218,23 @@ function Build-Mtgoupdater {
         cargo build
     }
     Set-Location ..
-    Write-Host "=== Done building MTGO Updater ==="
+    Write-Output "=== Done building MTGO Updater ==="
 }
 
 function Test-Mtgoupdater {
     Show-Versions
     Test-RustInstallation
-    Write-Host "==> Testing MTGO Updater..."
+    Write-Output "==> Testing MTGO Updater..."
     Set-Location mtgoupdater
 	cargo test -- --nocapture
     Set-Location ..
-    Write-Host "=== Done testing MTGO Updater ==="
+    Write-Output "=== Done testing MTGO Updater ==="
 }
 
 function Build-Mtgogui {
     Show-Versions
     Test-RustInstallation
-    Write-Host "==> Building MTGO GUI..."
+    Write-Output "==> Building MTGO GUI..."
     Set-Location mtgogui
     if ($BUILD_MODE -icontains "release") {
         cargo build -r
@@ -242,45 +242,45 @@ function Build-Mtgogui {
         cargo build
     }
     Set-Location ..
-    Write-Host "=== Done testing MTGO GUI ==="
+    Write-Output "=== Done testing MTGO GUI ==="
 }
 
 function Test-Mtgogui {
     Show-Versions
     Test-RustInstallation
-    Write-Host "==> Building MTGO GUI..."
+    Write-Output "==> Building MTGO GUI..."
     Set-Location mtgogui
     cargo test -- --nocapture
     Set-Location ..
-    Write-Host "=== Done testing MTGO GUI ==="
+    Write-Output "=== Done testing MTGO GUI ==="
 }
 
 function Build-Clean {
     Remove-Item -Path "mtgoparser/build" -Force -Recurse
-    Write-Host "mtgoparser cleaned"
+    Write-Output "mtgoparser cleaned"
     Set-Location mtgoupdater
     cargo clean
-    Write-Host "mtgoupdater cleaned"
+    Write-Output "mtgoupdater cleaned"
     Set-Location ..\mtgogetter
     go clean
-    Write-Host "mtgogetter cleaned"
+    Write-Output "mtgogetter cleaned"
     Set-Location ..\mtgogui
     cargo clean
     Set-Location -Path $PSScriptRoot
 }
 
 function Build-AndPack {
-    Write-Host "-------------------------------------"
-    Write-Host "==> Building and packing all binaries"
-    Write-Host "-------------------------------------"
+    Write-Output "-------------------------------------"
+    Write-Output "==> Building and packing all binaries"
+    Write-Output "-------------------------------------"
     $BUILD_MODE = "Release"
     # Only build MTGO GUI as it will build all dependencies in release mode.
     Build-Mtgogui
     Compress-GuiOnly
-    Write-Host "============================================== "
-    Write-Host "=== Done building and packing all binaries === "
-    Write-Host "===>   ${PACKAGE_NAME}.zip"
-    Write-Host "============================================== "
+    Write-Output "============================================== "
+    Write-Output "=== Done building and packing all binaries === "
+    Write-Output "===>   ${PACKAGE_NAME}.zip"
+    Write-Output "============================================== "
 }
 
 function Compress-MCM {
@@ -354,7 +354,7 @@ if ($targets.Contains($target)) {
 } elseif ($target -eq "default") {
     & $targets["all"]
 } else {
-    Write-Host "Available targets:"
-    $targets.Keys | ForEach-Object { Write-Host "  $_" }
+    Write-Output "Available targets:"
+    $targets.Keys | ForEach-Object { Write-Output "  $_" }
 }
 


### PR DESCRIPTION
Second jab at #81 

Add functionality to aggregate any amount of price history json files from a directory, into a single CSV file with price and quantity history in chronological order.

- [x] Functionality to read all previously processed price data JSON-files from a directory, in chronological order and aggregate is into a price history class containing historic data of user collection quantity and price data for each card.
- [x] Functionality to deserialize and serialize it to CSV
- [x] Functionality to read a previously aggregated CSV and append new price data and save it once again

### Future PRs:
- [ ] Functionality to continuously archive (zip) all files added to the price history CSV
- [ ] Add the behaviour to the `run update` scenario of `mtgo_preprocessor`
- [ ] Print the CSV to stdout and implement decoding etc. behaviour in the GUI