### PR TITLE
test CI still builds on MacOS/Windows

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -186,6 +186,8 @@ RUN rustup target add \
 
 WORKDIR /work
 
+RUN git config --global --add safe.directory /work
+
 FROM build-base as extras
 
 # Install optional dependecies

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,20 @@ FROM ubuntu:${VARIANT} as build-base
 # Restate the variant to use it later on in the llvm and cmake installations
 ARG VARIANT
 
+ARG HOST_USER
+ARG HOST_UID
+ARG HOST_GID
+
+
+# Ignore "WARNING: Running pip as the 'root' user can result in broken permissions..."
+ENV PIP_ROOT_USER_ACTION=ignore
+
+RUN groupadd --gid ${HOST_GID} ${HOST_USER} \
+    && useradd --uid ${HOST_UID} --gid ${HOST_GID} -m ${HOST_USER}
+
 # Install necessary packages available from standard repos
-RUN apt-get update -qq \
+RUN touch /in_container \
+    && apt-get update -qq \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
     # software-properties-common contains add-apt-repository
@@ -26,20 +38,9 @@ RUN apt-get update -qq \
     git \
     python3 \
     python3-pip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download and install Rust using the official Rust installer script
-RUN apt-get update \
-    && wget --progress=dot:giga -O - https://sh.rustup.rs | sh -s -- -y \
-    && apt-get install -y \
     build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Add the Rust binaries to the system PATH
-ENV PATH=$PATH:/root/.cargo/bin
-RUN rustc --version
 
 # User-settable versions:
 # This Dockerfile should support gcc-[7, 8, 9, 10, 11, 12, 13] and clang-[10, 11, 12, 13, 14, 15, 16, 17]
@@ -99,6 +100,8 @@ RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy $(which clang-t
 # Set clang-${LLVM_VER} as default clang
 RUN update-alternatives --install /usr/bin/clang clang $(which clang-${LLVM_VER}) 100
 RUN update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-${LLVM_VER}) 100
+# Set ld.lld to point to a matching LLVM version
+RUN update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-${LLVM_VER} 100
 
 # Add current cmake/ccmake, from Kitware
 ARG CMAKE_URL="https://apt.kitware.com/ubuntu/"
@@ -154,6 +157,14 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Download and install Rust using the official Rust installer script
+RUN wget --progress=dot:giga -O - https://sh.rustup.rs | sh -s -- -y 
+
+# Add the Rust binaries to the system PATH
+ENV PATH=/root/.cargo/bin:${PATH}
+RUN rustc --version
+RUN cargo install cargo-xwin
+
 
 # Allow the user to set compiler defaults
 ARG USE_CLANG
@@ -164,48 +175,18 @@ ENV CXX=${USE_CLANG:+"clang++"}
 ENV CC=${CC:-"gcc"}
 ENV CXX=${CXX:-"g++"}
 
-# Install editors
-RUN apt-get update -qq \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y --no-install-recommends \
-    neovim \
-    emacs \
-    nano \
+RUN rustup target add \
+    x86_64-pc-windows-gnu \
+    x86_64-pc-windows-msvc \
+    && rustup component add llvm-tools-preview \
+    && apt-get update -qq \
+    && apt-get install -y gcc-mingw-w64-x86-64 mingw-w64 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Include project
-ADD . /workspaces/mtgo-collection-manager
-WORKDIR /workspaces/mtgo-collection-manager
+WORKDIR /work
 
 FROM build-base as extras
-
-
-# Install include-what-you-use
-ENV IWYU /home/iwyu
-ENV IWYU_BUILD ${IWYU}/build
-ENV IWYU_SRC ${IWYU}/include-what-you-use
-RUN mkdir -p ${IWYU_BUILD} \
-    && git clone --branch clang_${LLVM_VER} \
-    https://github.com/include-what-you-use/include-what-you-use.git \
-    ${IWYU_SRC}
-RUN CC=clang-${LLVM_VER} \
-    CXX=clang++-${LLVM_VER} \
-    cmake -S ${IWYU_SRC} \
-    -B ${IWYU_BUILD} \
-    -G "Unix Makefiles" \
-    -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${LLVM_VER} \
-    && cmake --build ${IWYU_BUILD} -j \
-    && cmake --install ${IWYU_BUILD}
-
-# Per https://github.com/include-what-you-use/include-what-you-use#how-to-install:
-# `You need to copy the Clang include directory to the expected location before
-#  running (similarly, use include-what-you-use -print-resource-dir to learn
-#  exactly where IWYU wants the headers).`
-RUN mkdir -p $(include-what-you-use -print-resource-dir 2>/dev/null)
-RUN ln -s $(readlink -f /usr/lib/clang/${LLVM_VER}/include) \
-    $(include-what-you-use -print-resource-dir 2>/dev/null)/include
-
 
 # Install optional dependecies
 RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive \
@@ -217,20 +198,5 @@ RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive \
     cmake-curses-gui \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Install conan
-RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools \
-    && python3 -m pip install --no-cache-dir conan \
-    && conan --version
-
-# By default, anything you run in Docker is done as superuser.
-# Conan runs some install commands as superuser, and will prepend `sudo` to
-# these commands, unless `CONAN_SYSREQUIRES_SUDO=0` is in your env variables.
-ENV CONAN_SYSREQUIRES_SUDO 0
-# Some packages request that Conan use the system package manager to install
-# a few dependencies. This flag allows Conan to proceed with these installations;
-# leaving this flag undefined can cause some installation failures.
-ENV CONAN_SYSREQUIRES_MODE enabled
-
 
 CMD ["/bin/bash"]

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -93,7 +93,7 @@ jobs:
 ####                                   ####
       - name: 📩 Upload - MacOS 🍎
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-mtgo-collection-manager
           path: macos-13-${{ matrix.compiler }}-mtgo-cm.zip
@@ -104,7 +104,7 @@ jobs:
 ####                                      ####
       - name: 📩 Upload - Linux 🐧
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-mtgo-collection-manager
           path: ubuntu-22.04-${{ matrix.compiler }}-mtgo-cm.zip
@@ -115,7 +115,7 @@ jobs:
 ####                                      ####
       - name: 📩 Upload - Windows 💻
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-mtgo-collection-manager
           path: windows-2022-${{ matrix.compiler }}-mtgo-cm.zip
@@ -153,7 +153,7 @@ jobs:
           PACKAGE_NAME: windows-gcc-mtgo-cm
 
       - name: 📩 Upload - Linux-windows cross 💻🐧
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-mtgo-collection-manager
           path: windows-gcc-mtgo-cm.zip

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -123,7 +123,7 @@ jobs:
 
   Test-cross-windows:
     runs-on: ubuntu-latest
-    name: Test
+    name: Test cross compile to windows
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
@@ -131,23 +131,6 @@ jobs:
         uses: cardinalby/export-env-action@v2
         with:
           envFile: '.github/constants.env'
-      - uses: moonrepo/setup-rust@v1
-      - uses: aminya/setup-cpp@v1
-        with:
-          compiler: gcc
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: Setup Mold linker for Linux 🐧 builds
-        if: runner.os == 'Linux'
-        uses: rui314/setup-mold@v1
-
-      - name: Install Task
-        uses: arduino/setup-task@v1
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⚙️ Build devcontainer - Linux 🐧
         run: just build-devcontainer

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -149,19 +149,16 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ⚙️ Install development headers - Linux 🐧
-        run: source build-util/dev-ubuntu/install-ubuntu-fltk-dev-headers.sh
+      - name: ⚙️ Build devcontainer - Linux 🐧
+        run: just build-devcontainer
 
-      - name: Setup cross-compilation
-        run: just ci-install-cross-compile-windows-deps
-
-      - name: ⚒️ Build - 🍎🐧💻
+      - name: ⚒️ Build - 🐧💻
         # This doesn't actually build mtgogetter and parser for windows, but the important part is
         #  confirming cross-compilation abilities for fltk
-        run: just cross-compile-windows release
+        run: just cross-compile-windows-winx release
 
       - name: 📦 Pack/Archive - 🍎🐧💻
-        run: just archive-cross-compile-windows ${PACKAGE_NAME}
+        run: just archive-cross-compile-windows-xwin ${PACKAGE_NAME}
         env:
           PACKAGE_NAME: windows-gcc-mtgo-cm
 

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -134,8 +134,7 @@ jobs:
       - uses: moonrepo/setup-rust@v1
       - uses: aminya/setup-cpp@v1
         with:
-          vcvarsall: true
-          compiler: gcc-13
+          compiler: llvm-17
           cmake: true
           ninja: true
       - uses: actions/setup-go@v4

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -161,10 +161,7 @@ jobs:
       - name: ⚒️ Build - 🍎🐧💻
         # This doesn't actually build mtgogetter and parser for windows, but the important part is
         #  confirming cross-compilation abilities for fltk
-        run: |
-          task mtgogetter:build
-          task mtgoparser:build-for-integration
-          just cross-compile-windows release
+        run: just cross-compile-windows release
 
       - name: 📦 Pack/Archive - 🍎🐧💻
         run: just archive-cross-compile-windows ${PACKAGE_NAME}

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -140,7 +140,10 @@ jobs:
       - name: ⚒️ Build - 🐧💻
         # This doesn't actually build mtgogetter and parser for windows, but the important part is
         #  confirming cross-compilation abilities for fltk
-        run: just cross-compile-windows-xwin release
+        run: |
+          just build-mtgogetter
+          just build-mtgoparser
+          just cross-compile-windows-xwin release
         env:
           USE_CLANG: 0
 

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -132,11 +132,6 @@ jobs:
         with:
           envFile: '.github/constants.env'
       - uses: moonrepo/setup-rust@v1
-      - uses: aminya/setup-cpp@v1
-        with:
-          compiler: llvm-17
-          cmake: true
-          ninja: true
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -151,11 +151,15 @@ jobs:
 
       - name: ⚙️ Build devcontainer - Linux 🐧
         run: just build-devcontainer
+        env:
+          USE_CLANG: 0
 
       - name: ⚒️ Build - 🐧💻
         # This doesn't actually build mtgogetter and parser for windows, but the important part is
         #  confirming cross-compilation abilities for fltk
-        run: just cross-compile-windows-winx release
+        run: just cross-compile-windows-xwin release
+        env:
+          USE_CLANG: 0
 
       - name: 📦 Pack/Archive - 🍎🐧💻
         run: just archive-cross-compile-windows-xwin ${PACKAGE_NAME}

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -121,3 +121,61 @@ jobs:
           path: windows-2022-${{ matrix.compiler }}-mtgo-cm.zip
           retention-days: 14
 
+  Test-cross-windows:
+    runs-on: ubuntu-latest
+    name: Test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - name: 🗻 Export constants as environment variables 🏝️
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: '.github/constants.env'
+      - uses: moonrepo/setup-rust@v1
+      - uses: aminya/setup-cpp@v1
+        with:
+          vcvarsall: true
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Setup Mold linker for Linux 🐧 builds
+        if: runner.os == 'Linux'
+        uses: rui314/setup-mold@v1
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⚙️ Install development headers - Linux 🐧
+        run: source build-util/dev-ubuntu/install-ubuntu-fltk-dev-headers.sh
+
+      - name: Setup cross-compilation
+        run: just ci-install-cross-compile-windows-deps
+
+      - name: ⚒️ Build - 🍎🐧💻
+        # This doesn't actually build mtgogetter and parser for windows, but the important part is
+        #  confirming cross-compilation abilities for fltk
+        run: |
+          task mtgogetter:build
+          task mtgoparser:build-for-integration
+          just cross-compile-windows release
+
+      - name: 📦 Pack/Archive - 🍎🐧💻
+        run: just archive-cross-compile-windows ${PACKAGE_NAME}
+        env:
+          PACKAGE_NAME: windows-gcc-mtgo-cm
+
+      - name: 📩 Upload - Linux-windows cross 💻🐧
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-mtgo-collection-manager
+          path: windows-gcc-mtgo-cm.zip
+          retention-days: 14
+
+

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -132,6 +132,9 @@ jobs:
         with:
           envFile: '.github/constants.env'
       - uses: moonrepo/setup-rust@v1
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'

--- a/Justfile
+++ b/Justfile
@@ -73,8 +73,8 @@ archive-cross-compile-windows PACKAGE_NAME="windows-mtgo-collection-manager":
 
 archive-cross-compile-windows-xwin PACKAGE_NAME="windows-mtgo-collection-manager":
     mkdir -p mtgo-collection-manager
-    cp mtgogui/target/x86_64-pc-windows-msvc/release/mtgogui.exe mtgo-collection-manager/mtgo-collection-manager
-    zip -r {{PACKAGE_NAME}}.zip mtgo-collection-manager
+    cp mtgogui/target/x86_64-pc-windows-msvc/release/mtgogui.exe mtgo-collection-manager/mtgo-collection-manager.exe
+    zip -r {{PACKAGE_NAME}}.zip mtgo-collection-manager.exe
 
 
 clean: (cmd "cd mtgogui && cargo clean")

--- a/Justfile
+++ b/Justfile
@@ -57,6 +57,9 @@ ci-install-cross-compile-windows-deps:
     rustup target add x86_64-pc-windows-gnu 
     sudo apt-get install gcc-mingw-w64-x86-64 ninja-build cmake
 
+build-mtgoparser: (cmd 'task mtgoparser:build-for-integration')
+build-mtgogetter: (cmd 'task mtgogetter:build')
+
 cross-compile-windows PROFILE="dev":
     just cmd 'cd mtgogui && cargo build --profile={{PROFILE}} --target=x86_64-pc-windows-gnu'
 

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@
 
 ci-install-cross-compile-windows-deps:
     rustup target add x86_64-pc-windows-gnu 
-    sudo apt-get install gcc-mingw-w64-x86-64
+    sudo apt-get install gcc-mingw-w64-x86-64 ninja-build cmake
 
 cross-compile-windows PROFILE="dev":
     cd mtgogui && cargo build --profile={{PROFILE}} --target=x86_64-pc-windows-gnu

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+
+@_default:
+    just --list
+
+ci-install-cross-compile-windows-deps:
+    rustup target add x86_64-pc-windows-gnu 
+    sudo apt-get install gcc-mingw-w64-x86-64
+
+cross-compile-windows PROFILE="dev":
+    cd mtgogui && cargo build --profile={{PROFILE}} --target=x86_64-pc-windows-gnu
+
+
+archive-cross-compile-windows PACKAGE_NAME="windows-mtgo-collection-manager":
+    mkdir -p mtgo-collection-manager
+    cp mtgogui/target/x86_64-pc-windows-gnu/release/mtgogui.exe mtgo-collection-manager/mtgo-collection-manager
+    zip -r {{PACKAGE_NAME}}.zip mtgo-collection-manager

--- a/Justfile
+++ b/Justfile
@@ -1,16 +1,77 @@
+PWD := `pwd`
+USE_CLANG := env('USE_CLANG', '1')
+GCOV_EXECUTABLE := if USE_CLANG == "1" { "llvm-cov gcov" } else { "gcov" }
+CC  := if USE_CLANG == "1" { "/usr/bin/clang"   } else { "gcc" }
+CXX := if USE_CLANG == "1" { "/usr/bin/clang++" } else { "g++" }
+DEVCONTAINER_NAME := "mtgo-cm-devcontainer"
+CMD := if path_exists('/in_container') == "true" {
+"eval"
+} else {
+"docker run" \
++ " -e CC=" + CC \
++ " -e CXX=" + CXX \
++ " -e XWIN_CACHE_DIR=/work/xwin_cache"
++ " -v " + PWD + ":/work" \
++ " --rm" \
++ " -t " + DEVCONTAINER_NAME \
++ " /bin/bash -lc "
+}
+
+CMD_IT := if path_exists('/in_container') == "true" {
+"eval"
+} else {
+"docker run" \
++ " -e CC=" + CC \
++ " -e CXX=" + CXX \
++ " -v " + PWD + ":/work" \
++ " --rm" \
++ " -it " + DEVCONTAINER_NAME \
++ " /bin/bash -l "
+}
 
 @_default:
     just --list
+
+# Entry point to ensure commands are run within the container
+[no-exit-message]
+cmd *ARGS:
+    {{CMD}} '{{ ARGS }}'
+
+[no-exit-message]
+build-devcontainer UBUNTU_VARIANT="jammy":
+	docker build \
+		-t {{ DEVCONTAINER_NAME }} \
+		--build-arg USE_CLANG={{ USE_CLANG }} \
+		--build-arg VARIANT={{ UBUNTU_VARIANT }} \
+		--build-arg HOST_USER=${USER} \
+		--build-arg HOST_GID=$( id -g ) \
+		--build-arg HOST_UID=$( id -u ) \
+		-f .devcontainer/Dockerfile .
+
+[no-exit-message]
+run-devcontainer:
+	{{CMD_IT}}
+
 
 ci-install-cross-compile-windows-deps:
     rustup target add x86_64-pc-windows-gnu 
     sudo apt-get install gcc-mingw-w64-x86-64 ninja-build cmake
 
 cross-compile-windows PROFILE="dev":
-    cd mtgogui && cargo build --profile={{PROFILE}} --target=x86_64-pc-windows-gnu
+    just cmd 'cd mtgogui && cargo build --profile={{PROFILE}} --target=x86_64-pc-windows-gnu'
 
+cross-compile-windows-xwin PROFILE="dev":
+    just cmd 'cd mtgogui && cargo xwin build --profile={{PROFILE}} --target x86_64-pc-windows-msvc'
 
 archive-cross-compile-windows PACKAGE_NAME="windows-mtgo-collection-manager":
     mkdir -p mtgo-collection-manager
     cp mtgogui/target/x86_64-pc-windows-gnu/release/mtgogui.exe mtgo-collection-manager/mtgo-collection-manager
     zip -r {{PACKAGE_NAME}}.zip mtgo-collection-manager
+
+archive-cross-compile-windows-xwin PACKAGE_NAME="windows-mtgo-collection-manager":
+    mkdir -p mtgo-collection-manager
+    cp mtgogui/target/x86_64-pc-windows-msvc/release/mtgogui.exe mtgo-collection-manager/mtgo-collection-manager
+    zip -r {{PACKAGE_NAME}}.zip mtgo-collection-manager
+
+
+clean: (cmd "cd mtgogui && cargo clean")

--- a/mtgogui/.cargo/config.toml
+++ b/mtgogui/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"
+ar = "x86_64-w64-mingw32-gcc-ar"

--- a/mtgogui/Cargo.toml
+++ b/mtgogui/Cargo.toml
@@ -15,14 +15,14 @@ fltk-flex = "0.2"
 fltk-grid = "0.4"
 fltk-table = "0.3.1"
 fltk-theme = "0.7"
-mtgoupdater = { version = "0.1.0", path = "../mtgoupdater"}
+mtgoupdater = { version = "0.1.0", path = "../mtgoupdater" }
 url = "2.4.1"
 flexi_logger = { version = "0.27", features = ["async", "specfile"] }
 log = "0.4"
 serde = "1.0.190"
 toml = "0.8.6"
 serde_derive = "1.0.190"
-chrono =  { version = "0.4.31", features = ["serde"] }
+chrono = { version = "0.4.31", features = ["serde"] }
 regex = "1.10.2"
 once_cell = "1.18.0"
 

--- a/mtgogui/Cargo.toml
+++ b/mtgogui/Cargo.toml
@@ -10,11 +10,11 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fltk = { version = "1.4", features = ["fltk-bundled"] }
-fltk-flex = "0.2"
-fltk-grid = "0.4"
+fltk = { version = "1.4.21", features = ["fltk-bundled"] }
+fltk-flex = "0.2.1"
+fltk-grid = "0.4.0"
 fltk-table = "0.3.1"
-fltk-theme = "0.7"
+fltk-theme = "0.7.2"
 mtgoupdater = { version = "0.1.0", path = "../mtgoupdater" }
 url = "2.4.1"
 flexi_logger = { version = "0.27", features = ["async", "specfile"] }

--- a/mtgogui/Cargo.toml
+++ b/mtgogui/Cargo.toml
@@ -10,7 +10,7 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fltk = { version = "1.4.21", features = ["fltk-bundled"] }
+fltk = { version = "1.4.21" }                                         #, features = ["fltk-bundled"] }
 fltk-flex = "0.2.1"
 fltk-grid = "0.4.0"
 fltk-table = "0.3.1"


### PR DESCRIPTION
The build on main is broken somehow for windows and macos, why? Not sure.

## Changes
- Move away from using the bundled version of FLTK
    - Now using dynamic linking on MacOS (makes LLVM version work)
    - Cross compiling from ubuntu -> windows with cargo-xwin
- Rework dockerfile to be able to do cross compilation and prepare migration away from C++ 
- Bump upload artifact action from v3 -> v4