### PR TITLE
Add collection history tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "mtgogetter",
+ "once_cell",
  "parse_goatbots",
  "parse_scryfall",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ name = "mtgoparser"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "mtgogetter",
  "parse_goatbots",
  "parse_scryfall",
  "pretty_assertions",
@@ -1129,6 +1130,7 @@ dependencies = [
  "chrono",
  "mtgogetter",
  "mtgoparser",
+ "once_cell",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/mtgogetter/src/fetch_log.rs
+++ b/mtgogetter/src/fetch_log.rs
@@ -3,11 +3,11 @@ use std::{fs, io, path::Path};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-mod goatbots_md;
-use goatbots_md::GoatBotsMetaData;
+pub(crate) mod goatbots_md;
+pub(crate) use goatbots_md::GoatBotsMetaData;
 
-pub mod scryfall_md;
-use scryfall_md::ScryfallMetaData;
+pub(crate) mod scryfall_md;
+pub(crate) use scryfall_md::ScryfallMetaData;
 
 use self::scryfall_md::next_released_mtgo_set::NextReleasedMtgoSet;
 
@@ -44,6 +44,10 @@ impl CardInfoMetaData {
     pub fn to_toml_on_disk(&self, p: &Path) -> Result<(), io::Error> {
         let toml = toml::to_string(self).unwrap();
         fs::write(p, toml)
+    }
+
+    pub(crate) fn goatbots_metadata(&mut self) -> &mut GoatBotsMetaData {
+        &mut self.goatbots
     }
 
     pub fn goatbots_prices_updated_at(&self) -> Option<DateTime<Utc>> {

--- a/mtgogetter/src/fetch_log/goatbots_md.rs
+++ b/mtgogetter/src/fetch_log/goatbots_md.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, NaiveDateTime, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub(super) struct GoatBotsMetaData {
+pub(crate) struct GoatBotsMetaData {
     card_definitions_updated_at: Option<DateTime<Utc>>,
     prices_updated_at: Option<DateTime<Utc>>,
 }
@@ -23,15 +23,15 @@ impl GoatBotsMetaData {
         self.card_definitions_updated_at
     }
 
-    pub(super) fn refresh_card_definitions_updated_at_timestamp(&mut self) {
+    pub(crate) fn refresh_card_definitions_updated_at_timestamp(&mut self) {
         self.card_definitions_updated_at = Some(Utc::now())
     }
 
-    pub(super) fn prices_updated_at(&self) -> Option<DateTime<Utc>> {
+    pub(crate) fn prices_updated_at(&self) -> Option<DateTime<Utc>> {
         self.prices_updated_at
     }
 
-    pub(super) fn refresh_prices_updated_at_timestamp(&mut self) {
+    pub(crate) fn refresh_prices_updated_at_timestamp(&mut self) {
         self.prices_updated_at = Some(Utc::now())
     }
 

--- a/mtgogetter/src/lib.rs
+++ b/mtgogetter/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod fetch_log;
 
-use std::{fs, io, path::PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
 use get_scryfall::{MtgoSet, ScryfallBulkData, ScryfallBulkDataInfo, ScryfallMtgoSets};
 
@@ -34,7 +37,7 @@ pub fn fetch_all(save_to_dir: PathBuf) -> Result<(), io::Error> {
 // Download goatbots price history if they are not up-to-date
 fn fetch_goatboats_price_history(
     goatbots_metadata: &mut fetch_log::GoatBotsMetaData,
-    save_to_dir: &PathBuf,
+    save_to_dir: &Path,
 ) -> Result<(), io::Error> {
     if goatbots_metadata.is_price_updated() {
         log::info!("Prices are up to date - skipping download");
@@ -53,7 +56,7 @@ fn fetch_goatboats_price_history(
 // Download goatbots card definitions if they are not up-to-date
 fn fetch_goatbots_card_definitions(
     fetch_log: &mut CardInfoMetaData,
-    save_to_dir: &PathBuf,
+    save_to_dir: &Path,
 ) -> Result<(), io::Error> {
     if fetch_log.is_card_definitions_updated() {
         log::info!("Card definitions are up to date - skipping download");
@@ -72,7 +75,7 @@ fn fetch_goatbots_card_definitions(
 // Download scryfall bulk data if they are not up-to-date
 fn fetch_scryfall_bulk_data(
     fetch_log: &mut CardInfoMetaData,
-    save_to_dir: &PathBuf,
+    save_to_dir: &Path,
 ) -> Result<(), io::Error> {
     log::info!("Downloading scryfall bulk data INFO");
     let scryfall_bulk_info: ScryfallBulkDataInfo = ScryfallBulkDataInfo::get().unwrap();
@@ -94,7 +97,7 @@ fn fetch_scryfall_bulk_data(
 // Download scryfall sets if they are not up-to-date
 fn fetch_scryfall_sets(
     fetch_log: &mut CardInfoMetaData,
-    save_to_dir: &PathBuf,
+    save_to_dir: &Path,
 ) -> Result<(), io::Error> {
     if fetch_log.is_next_set_out() {
         log::info!("Fetching sets from Scryfall");

--- a/mtgogetter/src/lib.rs
+++ b/mtgogetter/src/lib.rs
@@ -6,7 +6,7 @@ use get_scryfall::{MtgoSet, ScryfallBulkData, ScryfallBulkDataInfo, ScryfallMtgo
 
 use crate::fetch_log::CardInfoMetaData;
 
-const FETCH_LOG_FILENAME: &str = "fetch_log.toml";
+pub const FETCH_LOG_FILENAME: &str = CardInfoMetaData::FILENAME;
 
 /// Fetches all data if any needs updating and stores it in `save_to_dir`
 ///
@@ -16,8 +16,86 @@ pub fn fetch_all(save_to_dir: PathBuf) -> Result<(), io::Error> {
         true => CardInfoMetaData::from_toml_file(&fetch_log_dst)?,
         false => CardInfoMetaData::new(),
     };
-    log::debug!("fetch log contents: {fetch_log:?}");
+    log::trace!("fetch log contents: {fetch_log:?}");
 
+    fetch_scryfall_sets(&mut fetch_log, &save_to_dir)?;
+
+    fetch_scryfall_bulk_data(&mut fetch_log, &save_to_dir)?;
+
+    fetch_goatbots_card_definitions(&mut fetch_log, &save_to_dir)?;
+
+    // Get price history
+    fetch_goatboats_price_history(fetch_log.goatbots_metadata(), &save_to_dir)?;
+
+    // Save the log to disk
+    fetch_log.to_toml_on_disk(&save_to_dir.join(CardInfoMetaData::FILENAME))
+}
+
+// Download goatbots price history if they are not up-to-date
+fn fetch_goatboats_price_history(
+    goatbots_metadata: &mut fetch_log::GoatBotsMetaData,
+    save_to_dir: &PathBuf,
+) -> Result<(), io::Error> {
+    if goatbots_metadata.is_price_updated() {
+        log::info!("Prices are up to date - skipping download");
+    } else {
+        log::info!("Fetching Goatbots price history");
+        let gb_price_hist = get_goatbots::get_goatbots_price_history();
+        let dst = save_to_dir.join("price-history.json");
+        log::info!("Writing Goatbots price history {dst:?}");
+        fs::write(dst, gb_price_hist)?;
+        log::info!("Refreshing timestamp for fetching Goatbots price history");
+        goatbots_metadata.refresh_prices_updated_at_timestamp();
+    }
+    Ok(())
+}
+
+// Download goatbots card definitions if they are not up-to-date
+fn fetch_goatbots_card_definitions(
+    fetch_log: &mut CardInfoMetaData,
+    save_to_dir: &PathBuf,
+) -> Result<(), io::Error> {
+    if fetch_log.is_card_definitions_updated() {
+        log::info!("Card definitions are up to date - skipping download");
+    } else {
+        log::info!("Fetching Card definitions");
+        let gb_card_defs = get_goatbots::get_goatbots_card_definitions();
+        let dst = save_to_dir.join("card-definitions.json");
+        log::info!("Writing Card definitions to {dst:?}");
+        fs::write(dst, gb_card_defs)?;
+        log::info!("Refreshing timestamp for fetching Goatbots card definitions");
+        fetch_log.refresh_card_definitions_updated_at_timestamp();
+    }
+    Ok(())
+}
+
+// Download scryfall bulk data if they are not up-to-date
+fn fetch_scryfall_bulk_data(
+    fetch_log: &mut CardInfoMetaData,
+    save_to_dir: &PathBuf,
+) -> Result<(), io::Error> {
+    log::info!("Downloading scryfall bulk data INFO");
+    let scryfall_bulk_info: ScryfallBulkDataInfo = ScryfallBulkDataInfo::get().unwrap();
+    log::trace!("scryfall bulk info: {scryfall_bulk_info:?}");
+    if fetch_log.is_scryfall_bulk_updated(scryfall_bulk_info.updated_at()) {
+        log::info!("Scryfall bulk data is up to date - skipping download")
+    } else {
+        log::info!("Fetching scryfall bulk data");
+        let scryfall_bulk_data = ScryfallBulkData::get(scryfall_bulk_info.updated_at()).unwrap();
+        fetch_log.refresh_bulk_data_updated_at_timestamp();
+        let cards = scryfall_bulk_data.take_cards();
+        let dst = save_to_dir.join(ScryfallBulkData::FILENAME);
+        log::info!("Writing scryfall bulk data (default cards) to {dst:?}");
+        fs::write(dst, serde_json::to_string(&cards).unwrap())?;
+    }
+    Ok(())
+}
+
+// Download scryfall sets if they are not up-to-date
+fn fetch_scryfall_sets(
+    fetch_log: &mut CardInfoMetaData,
+    save_to_dir: &PathBuf,
+) -> Result<(), io::Error> {
     if fetch_log.is_next_set_out() {
         log::info!("Fetching sets from Scryfall");
         let sets = ScryfallMtgoSets::get().unwrap();
@@ -31,48 +109,7 @@ pub fn fetch_all(save_to_dir: PathBuf) -> Result<(), io::Error> {
     } else {
         log::info!("Scryfall sets data is up to date - skipping download");
     }
-
-    let scryfall_bulk_info: ScryfallBulkDataInfo = ScryfallBulkDataInfo::get().unwrap();
-    log::info!("scryfall bulk info: {scryfall_bulk_info:?}");
-    if fetch_log.is_scryfall_bulk_updated(scryfall_bulk_info.updated_at()) {
-        log::info!("Scryfall bulk data is up to date - skipping download")
-    } else {
-        log::info!("Fetching scryfall bulk data");
-        let scryfall_bulk_data = ScryfallBulkData::get(scryfall_bulk_info.updated_at()).unwrap();
-        fetch_log.refresh_bulk_data_updated_at_timestamp();
-        let cards = scryfall_bulk_data.take_cards();
-        let dst = save_to_dir.join(ScryfallBulkData::FILENAME);
-        log::info!("Writing scryfall bulk data (default cards) to {dst:?}");
-        fs::write(dst, serde_json::to_string(&cards).unwrap())?;
-    }
-
-    if fetch_log.is_card_definitions_updated() {
-        log::info!("Card definitions are up to date - skipping download");
-    } else {
-        log::info!("Fetching Card definitions");
-        let gb_card_defs = get_goatbots::get_goatbots_card_definitions();
-        let dst = save_to_dir.join("card-definitions.json");
-        log::info!("Writing Card definitions to {dst:?}");
-        fs::write(dst, gb_card_defs)?;
-        log::info!("Refreshing timestamp for fetching Goatbots card definitions");
-        fetch_log.refresh_card_definitions_updated_at_timestamp();
-    }
-
-    // Get price history
-    if fetch_log.is_goatbots_prices_updated() {
-        log::info!("Prices are up to date - skipping download");
-    } else {
-        log::info!("Fetching Goatbots price history");
-        let gb_price_hist = get_goatbots::get_goatbots_price_history();
-        let dst = save_to_dir.join("price-history.json");
-        log::info!("Writing Goatbots price history {dst:?}");
-        fs::write(dst, gb_price_hist)?;
-        log::info!("Refreshing timestamp for fetching Goatbots price history");
-        fetch_log.refresh_prices_updated_at_timestamp();
-    }
-
-    // Save the log to disk
-    fetch_log.to_toml_on_disk(&save_to_dir.join(CardInfoMetaData::FILENAME))
+    Ok(())
 }
 
 #[cfg(test)]

--- a/mtgogui/src/appdata.rs
+++ b/mtgogui/src/appdata.rs
@@ -9,5 +9,3 @@ pub const APP_DATA_DIR: &str = "appdata";
 pub const CURRENT_FULL_TRADE_LIST: &str = "current-full-trade-list.dek";
 /// Name of the file that stores state information for the GUI
 pub const GUI_STATE: &str = "gui_state.toml";
-/// Name of the file that stores the state log for the MTGO getter
-pub const MTGO_GETTER_STATE_LOG: &str = "fetch_log.toml";

--- a/mtgogui/src/collection/processor.rs
+++ b/mtgogui/src/collection/processor.rs
@@ -126,8 +126,6 @@ impl TradelistProcessor {
 
                             // Get history instead of just collection
 
-
-
                             fadeout_progress_bar(sender.clone());
                             sender.send(Message::SetCollectionStats(CollectionStats::from_cards(
                                 &cards,

--- a/mtgogui/src/collection/processor.rs
+++ b/mtgogui/src/collection/processor.rs
@@ -124,6 +124,10 @@ impl TradelistProcessor {
                                 },
                             )));
 
+                            // Get history instead of just collection
+
+
+
                             fadeout_progress_bar(sender.clone());
                             sender.send(Message::SetCollectionStats(CollectionStats::from_cards(
                                 &cards,

--- a/mtgogui/src/collection/processor.rs
+++ b/mtgogui/src/collection/processor.rs
@@ -65,7 +65,7 @@ impl TradelistProcessor {
 
                     // Give the full trade list to the parser
                     // Find all the most recent files in the appdata directory, download and update them if necessary
-                    log::debug!("Instantiating appdata directory");
+                    log::info!("Instantiating appdata directory");
                     let appdata_paths = match AppData::update() {
                         Ok(paths) => paths,
                         Err(err) => {
@@ -84,16 +84,16 @@ impl TradelistProcessor {
                     )));
 
                     log::info!("Using MTGO Parser");
-                    log::info!("Scryfall path: {p:?}", p = appdata_paths.scryfall_path());
-                    log::info!(
+                    log::debug!("Scryfall path: {p:?}", p = appdata_paths.scryfall_path());
+                    log::debug!(
                         "Card definitions path: {p:?}",
                         p = appdata_paths.card_definitions_path()
                     );
-                    log::info!(
+                    log::debug!(
                         "Price history path: {p:?}",
                         p = appdata_paths.price_history_path()
                     );
-                    log::info!("Save to dir: {p:?}", p = appdata_paths.appdata_dir_path());
+                    log::debug!("Save to dir: {p:?}", p = appdata_paths.appdata_dir_path());
 
                     sender.send(Message::MenuBar(MenubarMessage::ProgressBar(
                         ProgressUpdate {
@@ -131,7 +131,7 @@ impl TradelistProcessor {
                             sender.send(Message::SetCards(cards));
                         }
                         Err(e) => {
-                            log::info!("MTGO Parser error: {e}");
+                            log::error!("MTGO Parser error: {e}");
                         }
                     }
                 }

--- a/mtgoparser/Cargo.toml
+++ b/mtgoparser/Cargo.toml
@@ -12,7 +12,7 @@ serde.workspace = true
 quick-xml.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
-
+once_cell.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/mtgoparser/Cargo.toml
+++ b/mtgoparser/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 [dependencies]
 parse_scryfall = { path = "parse_scryfall", version = "*" }
 parse_goatbots = { path = "parse_goatbots", version = "*" }
+mtgogetter = { path = "../mtgogetter", version = "*" }
 serde.workspace = true
 quick-xml.workspace = true
 serde_json.workspace = true

--- a/mtgoparser/src/lib.rs
+++ b/mtgoparser/src/lib.rs
@@ -3,6 +3,7 @@ use std::{fs, io, path::Path};
 use chrono::Utc;
 use collection::Collection;
 use mtgo_card::MtgoCard;
+use mtgogetter::FETCH_LOG_FILENAME;
 use parse_goatbots::{
     card_definitions::parse_card_def_json, price_history::parse_price_history_json,
 };
@@ -35,13 +36,12 @@ pub fn parse_full(
 
     if let Some(p) = save_json_to_dir {
         if has_state_log_changed(p) {
-            let fname = "fetch_log.toml";
-            let state_log_path = p.join(fname);
+            let state_log_path = p.join(FETCH_LOG_FILENAME);
             let hist_log_dir = p.join("collection-history");
             if !hist_log_dir.exists() {
                 fs::create_dir_all(&hist_log_dir).unwrap();
             }
-            let hist_log_path = hist_log_dir.join(fname);
+            let hist_log_path = hist_log_dir.join(FETCH_LOG_FILENAME);
             fs::copy(state_log_path, hist_log_path).unwrap();
         }
         // Save json
@@ -54,9 +54,10 @@ pub fn parse_full(
 }
 
 pub fn has_state_log_changed(appdata_dir: &Path) -> bool {
-    let fname = "fetch_log.toml";
-    let history_log_path = appdata_dir.join("collection-history").join(fname);
-    let appdata_log_path = appdata_dir.join(fname);
+    let history_log_path = appdata_dir
+        .join("collection-history")
+        .join(FETCH_LOG_FILENAME);
+    let appdata_log_path = appdata_dir.join(FETCH_LOG_FILENAME);
     if history_log_path.exists() {
         let app_log_md = fs::metadata(&appdata_log_path).unwrap();
         let hist_log_md = fs::metadata(history_log_path).unwrap();

--- a/mtgoparser/src/mtgo_card/card_history.rs
+++ b/mtgoparser/src/mtgo_card/card_history.rs
@@ -168,7 +168,7 @@ mod csv_row_helper {
         let mut name = first_element[1..].to_string();
 
         let mut found_end: bool = false;
-        while let Some(str_element) = iter.next() {
+        for str_element in iter.by_ref() {
             // Every additional element has to be prefixed with a comma since it was
             //  stripped by the split(',')-call
             name.push(',');

--- a/mtgoparser/src/mtgo_card/card_history.rs
+++ b/mtgoparser/src/mtgo_card/card_history.rs
@@ -1,6 +1,10 @@
 use super::{MtgoCard, Rarity};
 use serde::{Deserialize, Serialize};
 
+pub use price_history_tracker::PriceHistoryTracker;
+
+pub mod price_history_tracker;
+
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct CardHistory {
     pub id: u32,
@@ -9,7 +13,7 @@ pub struct CardHistory {
     pub set: String,
     pub rarity: Rarity,
     pub foil: bool,
-    pub price_history: Vec<(Option<u32>, Option<f32>, Option<f32>)>,
+    pub price_history: Vec<PriceHistoryTracker>,
 }
 
 impl CardHistory {
@@ -20,7 +24,7 @@ impl CardHistory {
         set: String,
         rarity: Rarity,
         foil: bool,
-        price_history: Vec<(Option<u32>, Option<f32>, Option<f32>)>,
+        price_history: Vec<PriceHistoryTracker>,
     ) -> Self {
         Self {
             id,
@@ -34,11 +38,12 @@ impl CardHistory {
     }
 
     pub fn from_mtgo_card(card: MtgoCard) -> Self {
-        let price_history = vec![(
-            Some(card.quantity),
-            Some(card.goatbots_price),
-            card.scryfall_price,
-        )];
+        let price_history_tracker = PriceHistoryTracker {
+            quantity: Some(card.quantity),
+            goatbots_price: Some(card.goatbots_price),
+            scryfall_price: card.scryfall_price,
+        };
+        let price_history = vec![price_history_tracker];
         Self {
             id: card.id,
             quantity: card.quantity.to_string(),
@@ -66,13 +71,22 @@ impl CardHistory {
         s.push(',');
         s.push_str(&self.foil.to_string());
 
-        for (quantity, gb_price, scryfall_price) in &self.price_history {
+        for PriceHistoryTracker {
+            quantity,
+            goatbots_price,
+            scryfall_price,
+        } in &self.price_history
+        {
             s.push(',');
             match quantity {
-                Some(q) => s.push_str(&format!("[{q}]")),
-                None => s.push_str(""),
+                Some(q) => {
+                    s.push('[');
+                    s.push_str(&q.to_string());
+                    s.push(']');
+                }
+                None => (),
             }
-            match gb_price {
+            match goatbots_price {
                 Some(p) => s.push_str(p.to_string().as_str()),
                 None => s.push('-'),
             }
@@ -85,31 +99,15 @@ impl CardHistory {
         s
     }
 
-    pub fn csv_row_to_card_history(row: String) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut iter = row.split(',');
-        let id = iter.next().unwrap().parse()?;
-        let quantity = iter.next().unwrap().to_string();
-        let name = iter.next().unwrap().to_string();
-        let set = iter.next().unwrap().to_string();
-        let rarity = Rarity::from(iter.next().unwrap());
-        let foil = iter.next().unwrap().parse()?;
-        let mut price_history = Vec::new();
-        for price in iter {
-            let mut price_iter = price.split(';');
-            let quantity = match price_iter.next().unwrap() {
-                "" => None,
-                q => Some(q.parse().unwrap()),
-            };
-            let gb_price = match price_iter.next().unwrap() {
-                "-" => None,
-                p => Some(p.parse().unwrap()),
-            };
-            let scryfall_price = match price_iter.next().unwrap() {
-                "-" => None,
-                p => Some(p.parse().unwrap()),
-            };
-            price_history.push((quantity, gb_price, scryfall_price));
-        }
+    pub fn from_csv_row(row: String) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut iter: std::str::Split<char> = row.split(',');
+        let id = csv_row_helper::col0_id(&mut iter)?;
+        let quantity = csv_row_helper::col1_quantity(&mut iter)?.to_string();
+        let name = csv_row_helper::col2_name(&mut iter);
+        let set = csv_row_helper::col3_set(&mut iter);
+        let rarity = csv_row_helper::col4_rarity(&mut iter);
+        let foil = csv_row_helper::col5_foil(&mut iter)?;
+        let price_history = csv_row_helper::col6_to_col_n(&mut iter);
         Ok(Self {
             id,
             quantity,
@@ -119,5 +117,259 @@ impl CardHistory {
             foil,
             price_history,
         })
+    }
+}
+
+// Helpers for making it more readable to parse from csv frow
+mod csv_row_helper {
+    use std::{
+        num::ParseIntError,
+        str::{ParseBoolError, Split},
+    };
+
+    use crate::mtgo_card::Rarity;
+
+    use super::PriceHistoryTracker;
+    // Advances the iterator and parses the next element as u32
+    fn next_parse_to_int(iter: &mut Split<char>) -> Result<u32, ParseIntError> {
+        iter.next().unwrap().parse()
+    }
+
+    // Advances the iterator and returns the next element as an owned string
+    fn next_to_string(iter: &mut Split<char>) -> String {
+        iter.next().unwrap().to_string()
+    }
+
+    // Advances the iterator and parses the next element as bool
+    fn next_parse_to_bool(iter: &mut Split<char>) -> Result<bool, ParseBoolError> {
+        iter.next().unwrap().parse()
+    }
+
+    // First column contains id
+    pub fn col0_id(iter: &mut Split<char>) -> Result<u32, ParseIntError> {
+        next_parse_to_int(iter)
+    }
+
+    pub fn col1_quantity(iter: &mut Split<char>) -> Result<u32, ParseIntError> {
+        next_parse_to_int(iter)
+    }
+
+    // The name string is quoted (because MTG names can contain all sorts of characters) so we remove the extra quotes after parsing
+    pub fn col2_name(iter: &mut Split<char>) -> String {
+        let first_element = iter.next().unwrap();
+        // If the first element ends with '"' then it contained the entire name and we return
+        if first_element.ends_with('"') {
+            return first_element[1..first_element.len() - 1].to_string();
+        }
+        // If the first element doesn't end with '"' that means it contains
+        // commas (,) and was split over several element in the CSV row, so we iterate
+        // until we find the element that ends with '"' and add all ther intermediate strings
+        // to the following variable:
+        let mut name = first_element[1..].to_string();
+
+        let mut found_end: bool = false;
+        while let Some(str_element) = iter.next() {
+            // Every additional element has to be prefixed with a comma since it was
+            //  stripped by the split(',')-call
+            name.push(',');
+            if str_element.ends_with('"') {
+                found_end = true;
+                name.push_str(&str_element[0..str_element.len() - 1]);
+                break;
+            } else {
+                // Another substring so we add it and continue
+                name.push_str(str_element);
+            }
+        }
+        if !found_end {
+            panic!("Reached end while parsing card history card name without encountering a closing quote (\")")
+        }
+        name
+    }
+
+    pub fn col3_set(iter: &mut Split<char>) -> String {
+        next_to_string(iter)
+    }
+
+    pub fn col4_rarity(iter: &mut Split<char>) -> Rarity {
+        Rarity::from(iter.next().unwrap())
+    }
+
+    pub fn col5_foil(iter: &mut Split<char>) -> Result<bool, ParseBoolError> {
+        next_parse_to_bool(iter)
+    }
+
+    // Parse a price element from the `PriceHistoryTracker` part of a CSV row
+    fn parse_price_element(price_iter: &mut Split<char>) -> Option<f32> {
+        match price_iter.next().unwrap() {
+            "-" => None,
+            p => Some(p.parse().unwrap()),
+        }
+    }
+
+    fn parse_quantity_and_goatbots_element(
+        price_iter: &mut Split<char>,
+    ) -> (Option<u32>, Option<f32>) {
+        let quant_and_gb_element = price_iter.next().unwrap();
+        let element_has_quantity = quant_and_gb_element.get(0..1).unwrap() == "[";
+
+        let quantity_end_pos: Option<usize> = quant_and_gb_element.find(']');
+
+        let quantity: Option<u32> = if element_has_quantity {
+            let quantity_str = quant_and_gb_element
+                .get(1..quantity_end_pos.unwrap())
+                .unwrap();
+            Some(quantity_str.parse().unwrap())
+        } else {
+            None
+        };
+
+        let goatbots_price_str = if element_has_quantity {
+            quant_and_gb_element
+                .get(quantity_end_pos.unwrap() + 1..)
+                .unwrap()
+        } else {
+            quant_and_gb_element
+        };
+        let goatbots_price: Option<f32> = Some(goatbots_price_str.parse().unwrap());
+
+        (quantity, goatbots_price)
+    }
+
+    pub fn col6_to_col_n(iter: &mut Split<char>) -> Vec<PriceHistoryTracker> {
+        let mut price_history = Vec::new();
+        for price in iter {
+            let mut price_iter = price.split(';');
+            let (quantity, goatbots_price) = parse_quantity_and_goatbots_element(&mut price_iter);
+            let scryfall_price = parse_price_element(&mut price_iter);
+            price_history.push(PriceHistoryTracker {
+                quantity,
+                goatbots_price,
+                scryfall_price,
+            });
+        }
+        price_history
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use testresult::TestResult;
+
+    use super::*;
+
+    const EXAMPLE_BLACK_LOTUS_CSV_ROW: &str = r#"1,3,"Black Lotus",1E,Rare,false,[3]1.23;3.45"#;
+    // Name and set are heap allocated so we cannot simply make a const instance
+    fn example_black_lotus_mtgo_card() -> MtgoCard {
+        MtgoCard {
+            id: 1,
+            quantity: 3,
+            name: "Black Lotus".into(),
+            set: "1E".into(),
+            rarity: Rarity::Rare,
+            foil: false,
+            goatbots_price: 1.23,
+            scryfall_price: Some(3.45),
+        }
+    }
+
+    const EXAMPLE_ARLINN_THE_PACKS_HOPE_CSV_ROW: &str = r#"94060,40,"Arlinn, the Pack's Hope",MID,Mythic,false,[1004]2.1;-,[900]3;3.04,[1]7.03;10.9,9.93;10,8;8,4.57;4.1,2.57;-,[40]2.57;2"#;
+    fn example_arlinn_the_packs_hope_card_history() -> CardHistory {
+        CardHistory {
+            id: 94060,
+            quantity: "40".into(),
+            name: "Arlinn, the Pack's Hope".into(),
+            set: "MID".into(),
+            rarity: Rarity::Mythic,
+            foil: false,
+            // A history with selling a big quantity as price goes up, eventually having a quantity of 0
+            // then when price is low again, buying to a quantity of 40
+            price_history: vec![
+                PriceHistoryTracker {
+                    quantity: Some(1004),
+                    goatbots_price: Some(2.1),
+                    scryfall_price: None,
+                },
+                PriceHistoryTracker {
+                    quantity: Some(900),
+                    goatbots_price: Some(3.),
+                    scryfall_price: Some(3.04),
+                },
+                PriceHistoryTracker {
+                    quantity: Some(1),
+                    goatbots_price: Some(7.03),
+                    scryfall_price: Some(10.9),
+                },
+                PriceHistoryTracker {
+                    quantity: None,
+                    goatbots_price: Some(9.93),
+                    scryfall_price: Some(10.),
+                },
+                PriceHistoryTracker {
+                    quantity: None,
+                    goatbots_price: Some(8.),
+                    scryfall_price: Some(8.),
+                },
+                PriceHistoryTracker {
+                    quantity: None,
+                    goatbots_price: Some(4.57),
+                    scryfall_price: Some(4.1),
+                },
+                PriceHistoryTracker {
+                    quantity: None,
+                    goatbots_price: Some(2.57),
+                    scryfall_price: None,
+                },
+                PriceHistoryTracker {
+                    quantity: Some(40),
+                    goatbots_price: Some(2.57),
+                    scryfall_price: Some(2.),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    pub fn test_to_csv_row() -> TestResult {
+        let mtgo_card = example_black_lotus_mtgo_card();
+        let card_history = CardHistory::from_mtgo_card(mtgo_card.clone());
+        assert_eq!(card_history.id, mtgo_card.id);
+
+        let csv_row = card_history.to_csv_row();
+        assert_eq!(csv_row, EXAMPLE_BLACK_LOTUS_CSV_ROW);
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_from_csv_row() -> TestResult {
+        let card_history =
+            CardHistory::from_csv_row(EXAMPLE_BLACK_LOTUS_CSV_ROW.to_owned()).unwrap();
+
+        assert_eq!(
+            card_history,
+            CardHistory::from_mtgo_card(example_black_lotus_mtgo_card())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_to_csv_row_with_longer_history() -> TestResult {
+        let card_history = example_arlinn_the_packs_hope_card_history();
+        let csv_row = card_history.to_csv_row();
+        assert_eq!(csv_row, EXAMPLE_ARLINN_THE_PACKS_HOPE_CSV_ROW);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_from_csv_row_with_longer_history() -> TestResult {
+        let card_history =
+            CardHistory::from_csv_row(EXAMPLE_ARLINN_THE_PACKS_HOPE_CSV_ROW.to_owned()).unwrap();
+
+        assert_eq!(card_history, example_arlinn_the_packs_hope_card_history());
+
+        Ok(())
     }
 }

--- a/mtgoparser/src/mtgo_card/card_history/price_history_tracker.rs
+++ b/mtgoparser/src/mtgo_card/card_history/price_history_tracker.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PriceHistoryTracker {
+    pub quantity: Option<u32>,
+    pub goatbots_price: Option<f32>,
+    pub scryfall_price: Option<f32>,
+}

--- a/mtgoparser/src/mtgo_card/card_history/price_history_tracker.rs
+++ b/mtgoparser/src/mtgo_card/card_history/price_history_tracker.rs
@@ -6,3 +6,17 @@ pub struct PriceHistoryTracker {
     pub goatbots_price: Option<f32>,
     pub scryfall_price: Option<f32>,
 }
+
+impl PriceHistoryTracker {
+    pub fn new(
+        quantity: Option<u32>,
+        goatbots_price: Option<f32>,
+        scryfall_price: Option<f32>,
+    ) -> Self {
+        Self {
+            quantity,
+            goatbots_price,
+            scryfall_price,
+        }
+    }
+}

--- a/mtgoparser/src/mtgo_card/collection_history.rs
+++ b/mtgoparser/src/mtgo_card/collection_history.rs
@@ -1,4 +1,9 @@
-use super::card_history::{CardHistory, PriceHistoryTracker};
+use std::cmp::Ordering;
+
+use super::{
+    card_history::{CardHistory, PriceHistoryTracker},
+    MtgoCard,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CardHistoryAggregate {
@@ -23,7 +28,13 @@ pub struct CollectionHistory {
 }
 
 impl CollectionHistory {
-    pub fn from_card_history(timestamp: String, card_history: Vec<CardHistory>) -> Self {
+    pub fn from_card_history(timestamps: Vec<String>, card_history: Vec<CardHistory>) -> Self {
+        debug_assert_eq!(
+            timestamps.len(),
+            // Choose last because first will always be tix
+            card_history.last().unwrap().price_history.len(),
+            "Expected timestamps and length of price_history to be the same"
+        );
         let mut card_histories: Vec<CardHistoryAggregate> = vec![];
         for cardh in card_history.into_iter() {
             let mut newest_quantity = 0;
@@ -42,11 +53,137 @@ impl CollectionHistory {
         }
 
         Self {
-            timestamps: vec![timestamp],
+            timestamps,
             card_histories,
         }
     }
 
+    pub fn add_new_card_data(&mut self, timestamp: String, cards: Vec<MtgoCard>) {
+        let mut card_history: Vec<CardHistory> =
+            cards.into_iter().map(CardHistory::from_mtgo_card).collect();
+        card_history.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+        debug_assert!(card_history.first().unwrap().id < card_history.last().unwrap().id);
+        self.card_histories
+            .sort_unstable_by(|a, b| a.card_history.id.cmp(&b.card_history.id));
+        debug_assert!(
+            self.card_histories.first().unwrap().card_history.id
+                < self.card_histories.last().unwrap().card_history.id
+        );
+        // Make the card history aligned to the current collection history
+        let mut new_cards: Vec<CardHistory> = vec![];
+        let mut new_cards_iter = card_history.into_iter();
+        let mut current_new_card = new_cards_iter.next();
+        let mut iterate_new_card = false;
+
+        for old_card in self.card_histories.iter_mut() {
+            if iterate_new_card {
+                iterate_new_card = false;
+                current_new_card = new_cards_iter.next();
+            }
+            let old_card_id = old_card.card_history.id;
+            if let Some(new_card) = current_new_card.as_mut() {
+                let new_id = new_card.id;
+                match old_card_id.cmp(&new_id) {
+                    Ordering::Less => {
+                        old_card.newest_quantity = 0;
+                        old_card
+                            .card_history
+                            .price_history
+                            .push(PriceHistoryTracker::new(Some(0), None, None));
+                    }
+                    Ordering::Equal => {
+                        debug_assert_eq!(new_card.price_history.len(), 1);
+                        let mut price_history = new_card.price_history.pop().unwrap();
+                        // If the quantity didn't change, we don't add it to the data.
+                        let new_card_quantity = price_history.quantity.unwrap();
+                        if new_card_quantity == old_card.newest_quantity {
+                            price_history.quantity = None;
+                        } else {
+                            old_card.newest_quantity = new_card_quantity;
+                        }
+                        old_card.card_history.price_history.push(price_history);
+
+                        iterate_new_card = true;
+                    }
+                    Ordering::Greater => {
+                        new_cards.push(new_card.clone());
+                        iterate_new_card = true;
+                        loop {
+                            if iterate_new_card {
+                                current_new_card = new_cards_iter.next();
+                            }
+                            if let Some(new_card) = current_new_card.as_mut() {
+                                let new_id = new_card.id;
+                                match old_card_id.cmp(&new_id) {
+                                    Ordering::Less => {
+                                        old_card.newest_quantity = 0;
+                                        old_card
+                                            .card_history
+                                            .price_history
+                                            .push(PriceHistoryTracker::new(Some(0), None, None));
+                                        break;
+                                    }
+                                    Ordering::Equal => {
+                                        debug_assert_eq!(new_card.price_history.len(), 1);
+                                        let mut price_history =
+                                            new_card.price_history.pop().unwrap();
+                                        // If the quantity didn't change, we don't add it to the data.
+                                        let new_card_quantity = price_history.quantity.unwrap();
+                                        if new_card_quantity == old_card.newest_quantity {
+                                            price_history.quantity = None;
+                                        } else {
+                                            old_card.newest_quantity = new_card_quantity;
+                                        }
+                                        old_card.card_history.price_history.push(price_history);
+
+                                        iterate_new_card = true;
+                                        break;
+                                    }
+                                    Ordering::Greater => {
+                                        new_cards.push(new_card.clone());
+                                        iterate_new_card = true;
+                                    }
+                                }
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else {
+                old_card.newest_quantity = 0;
+                old_card
+                    .card_history
+                    .price_history
+                    .push(PriceHistoryTracker::new(Some(0), None, None));
+            }
+        }
+
+        // Now all the cards that already existed in the price history have been updated
+        // with the new price data.
+        // So next we add the new cards, they first need to be "zero"-extended with all the timestamps before they
+        // were added to the collection.
+        let prev_timestamps_count = self.timestamps.len();
+        let prefix_extend_vec: Vec<PriceHistoryTracker> =
+            std::iter::repeat(PriceHistoryTracker::default())
+                .take(prev_timestamps_count)
+                .collect();
+        for mut new_c in new_cards.into_iter() {
+            let mut prefix_extend_vec_inst = prefix_extend_vec.clone();
+            let ph = new_c.price_history.pop().unwrap();
+            prefix_extend_vec_inst.push(ph);
+            new_c.price_history = prefix_extend_vec_inst;
+            let newest_quantity = new_c.quantity.parse().unwrap();
+            self.card_histories.push(CardHistoryAggregate {
+                card_history: new_c,
+                newest_quantity,
+            });
+        }
+        // Finally add the new timestamp
+        self.timestamps.push(timestamp);
+    }
+
+    /// Creates an instance from
     pub fn from_collection_history(
         card_histories: Vec<CardHistoryAggregate>,
         timestamps: Vec<String>,
@@ -58,6 +195,45 @@ impl CollectionHistory {
     }
 
     pub fn size(&self) -> usize {
+        debug_assert_eq!(self.card_histories.len(), self.timestamps.len());
         self.card_histories.len()
+    }
+
+    pub fn to_csv_string(&mut self) -> String {
+        self.card_histories
+            .sort_unstable_by(|a, b| a.card_history.id.cmp(&b.card_history.id));
+        // Length of a timestamp, e.g. `2023-11-06T083944Z`
+        const TIMESTAMP_LEN: usize = 18;
+        // Approximate length of the first entry of a card
+        // e.g. `106471,1,"Dragonwing Glider",ONE,Rare,false,[1]0.04;0.02`
+        const APPROX_FIRST_ENTRY_CARD_LEN: usize = 64;
+        // Approximate length of subsequent entries of a card
+        // e.g. `0.003;0.03` or `-,-`
+        const APPROX_SUBSEQUENT_ENTRY_CARD_LEN: usize = 8;
+        // Make a rough approximation of how much memory we need to allocate for the string
+        // to prevent many small (but larger and larger) allocations/reallocations+copy/move
+        let approx_prealloc = (self.timestamps.len() * TIMESTAMP_LEN)
+            + (self.timestamps.len() * APPROX_SUBSEQUENT_ENTRY_CARD_LEN)
+            + (self.card_histories.len() * APPROX_FIRST_ENTRY_CARD_LEN);
+        let mut timestamp_row = String::with_capacity(approx_prealloc);
+
+        for ts in self.timestamps.iter() {
+            if timestamp_row.is_empty() {
+                timestamp_row.push_str(ts);
+            } else {
+                timestamp_row.push(',');
+                timestamp_row.push_str(ts);
+            }
+        }
+        timestamp_row.push('\n');
+
+        eprintln!("{timestamp_row}");
+
+        for c in self.card_histories.iter() {
+            let s = c.card_history.to_csv_row();
+            timestamp_row.push_str(&s);
+            timestamp_row.push('\n');
+        }
+        timestamp_row
     }
 }

--- a/mtgoparser/src/mtgo_card/collection_history.rs
+++ b/mtgoparser/src/mtgo_card/collection_history.rs
@@ -195,7 +195,6 @@ impl CollectionHistory {
     }
 
     pub fn size(&self) -> usize {
-        debug_assert_eq!(self.card_histories.len(), self.timestamps.len());
         self.card_histories.len()
     }
 

--- a/mtgoparser/src/mtgo_card/collection_history.rs
+++ b/mtgoparser/src/mtgo_card/collection_history.rs
@@ -1,4 +1,4 @@
-use super::card_history::CardHistory;
+use super::card_history::{CardHistory, PriceHistoryTracker};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CardHistoryAggregate {
@@ -27,8 +27,13 @@ impl CollectionHistory {
         let mut card_histories: Vec<CardHistoryAggregate> = vec![];
         for cardh in card_history.into_iter() {
             let mut newest_quantity = 0;
-            for (quant, _, _) in cardh.price_history.iter().rev() {
-                if let Some(q) = quant {
+            for PriceHistoryTracker {
+                quantity,
+                goatbots_price: _,
+                scryfall_price: _,
+            } in cardh.price_history.iter().rev()
+            {
+                if let Some(q) = quantity {
                     newest_quantity = *q;
                     break;
                 }

--- a/mtgoparser/tests/mtgoparser.rs
+++ b/mtgoparser/tests/mtgoparser.rs
@@ -4,6 +4,7 @@ use mtgoparser::{
     mtgo_card::{card_history::CardHistory, collection_history::CollectionHistory},
     xml::parse_dek_xml,
 };
+use once_cell::sync::Lazy;
 use parse_goatbots::{
     card_definitions::parse_card_def_json, price_history::parse_price_history_json,
 };
@@ -15,25 +16,35 @@ use std::{
 };
 use testresult::TestResult;
 
+static SCRYFALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgogetter-out/scryfall-20231002-full.json"));
+static SCRYFALL_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/scryfall/default-cards-small-5cards.json"));
+static CARD_DEFINITIONS_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json"));
+static CARD_DEFINITIONS_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-defs-small-5cards.json"));
+static PRICE_HISTORY_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json"));
+static PRICE_HISTORY_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-hist-small-5cards.json"));
+static FULL_TRADELIST_MEDIUM_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek"));
+static FULL_TRADELIST_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from(r"../test/test-data/mtgo/Full Trade List-small-5cards.dek"));
+
 #[test]
 pub fn test_collection_parse_small() -> TestResult {
-    let xml_cards = parse_dek_xml(Path::new(
-        r"../test/test-data/mtgo/Full Trade List-small-5cards.dek",
-    ))?;
+    let xml_cards = parse_dek_xml(FULL_TRADELIST_SMALL_FULL_PATH.as_path())?;
     assert_eq!(xml_cards.len(), 5);
 
-    let price_hist = parse_price_history_json(Path::new(
-        r"../test/test-data/goatbots/price-hist-small-5cards.json",
-    ))?;
+    let price_hist = parse_price_history_json(PRICE_HISTORY_SMALL_FULL_PATH.as_path())?;
     assert_eq!(price_hist.len(), 5);
 
-    let goatbots_card_defs = parse_card_def_json(Path::new(
-        r"../test/test-data/goatbots/card-defs-small-5cards.json",
-    ))?;
+    let goatbots_card_defs = parse_card_def_json(CARD_DEFINITIONS_SMALL_FULL_PATH.as_path())?;
     assert_eq!(goatbots_card_defs.len(), 5);
 
-    let scryfall_json_str =
-        fs::read_to_string("../test/test-data/scryfall/default-cards-small-5cards.json")?;
+    let scryfall_json_str = fs::read_to_string(SCRYFALL_SMALL_FULL_PATH.as_path())?;
     let scryfall_cards: Vec<ScryfallCard> = serde_json::from_str(&scryfall_json_str)?;
     assert_eq!(scryfall_cards.len(), 5);
 
@@ -117,23 +128,16 @@ pub fn test_collection_parse_small() -> TestResult {
 
 #[test]
 pub fn test_collection_parse_medium() -> TestResult {
-    let xml_cards = parse_dek_xml(Path::new(
-        r"../test/test-data/mtgo/Full Trade List-medium-3000cards.dek",
-    ))?;
+    let xml_cards = parse_dek_xml(FULL_TRADELIST_MEDIUM_FULL_PATH.as_path())?;
     assert_eq!(xml_cards.len(), 3000);
 
-    let price_hist = parse_price_history_json(Path::new(
-        r"../test/test-data/goatbots/price-history-2023-10-02-full.json",
-    ))?;
+    let price_hist = parse_price_history_json(PRICE_HISTORY_FULL_PATH.as_path())?;
     assert_eq!(price_hist.len(), 76070);
 
-    let goatbots_card_defs = parse_card_def_json(Path::new(
-        r"../test/test-data/goatbots/card-definitions-2023-10-02-full.json",
-    ))?;
+    let goatbots_card_defs = parse_card_def_json(CARD_DEFINITIONS_FULL_PATH.as_path())?;
     assert_eq!(goatbots_card_defs.len(), 76070);
 
-    let scryfall_json_str =
-        fs::read_to_string("../test/test-data/mtgogetter-out/scryfall-20231002-full.json")?;
+    let scryfall_json_str = fs::read_to_string(SCRYFALL_FULL_PATH.as_path())?;
     let scryfall_cards: Vec<ScryfallCard> = serde_json::from_str(&scryfall_json_str)?;
     assert_eq!(scryfall_cards.len(), 43705);
 
@@ -155,23 +159,16 @@ pub fn test_collection_parse_medium() -> TestResult {
 
 #[test]
 fn test_collection_parse_medium_prices() -> TestResult {
-    let xml_cards = parse_dek_xml(Path::new(
-        r"../test/test-data/mtgo/Full Trade List-medium-3000cards.dek",
-    ))?;
+    let xml_cards = parse_dek_xml(FULL_TRADELIST_MEDIUM_FULL_PATH.as_path())?;
     assert_eq!(xml_cards.len(), 3000);
 
-    let price_hist = parse_price_history_json(Path::new(
-        r"../test/test-data/goatbots/price-history-2023-10-02-full.json",
-    ))?;
+    let price_hist = parse_price_history_json(PRICE_HISTORY_FULL_PATH.as_path())?;
     assert_eq!(price_hist.len(), 76070);
 
-    let goatbots_card_defs = parse_card_def_json(Path::new(
-        r"../test/test-data/goatbots/card-definitions-2023-10-02-full.json",
-    ))?;
+    let goatbots_card_defs = parse_card_def_json(CARD_DEFINITIONS_FULL_PATH.as_path())?;
     assert_eq!(goatbots_card_defs.len(), 76070);
 
-    let scryfall_json_str =
-        fs::read_to_string("../test/test-data/mtgogetter-out/scryfall-20231002-full.json")?;
+    let scryfall_json_str = fs::read_to_string(SCRYFALL_FULL_PATH.as_path())?;
     let scryfall_cards: Vec<ScryfallCard> = serde_json::from_str(&scryfall_json_str)?;
     assert_eq!(scryfall_cards.len(), 43705);
 

--- a/mtgoparser/tests/mtgoparser.rs
+++ b/mtgoparser/tests/mtgoparser.rs
@@ -4,34 +4,14 @@ use mtgoparser::{
     mtgo_card::{card_history::CardHistory, collection_history::CollectionHistory},
     xml::parse_dek_xml,
 };
-use once_cell::sync::Lazy;
 use parse_goatbots::{
     card_definitions::parse_card_def_json, price_history::parse_price_history_json,
 };
 use parse_scryfall::ScryfallCard;
 use pretty_assertions::assert_eq;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-use testresult::TestResult;
 
-static SCRYFALL_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/mtgogetter-out/scryfall-20231002-full.json"));
-static SCRYFALL_SMALL_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/scryfall/default-cards-small-5cards.json"));
-static CARD_DEFINITIONS_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json"));
-static CARD_DEFINITIONS_SMALL_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-defs-small-5cards.json"));
-static PRICE_HISTORY_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json"));
-static PRICE_HISTORY_SMALL_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-hist-small-5cards.json"));
-static FULL_TRADELIST_MEDIUM_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek"));
-static FULL_TRADELIST_SMALL_FULL_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from(r"../test/test-data/mtgo/Full Trade List-small-5cards.dek"));
+mod util;
+use util::*;
 
 #[test]
 pub fn test_collection_parse_small() -> TestResult {
@@ -115,7 +95,7 @@ pub fn test_collection_parse_small() -> TestResult {
     assert_eq!(card_history.len(), 5);
 
     let collection_history = CollectionHistory::from_card_history(
-        most_recent_ts.to_rfc3339_opts(SecondsFormat::Secs, true),
+        vec![most_recent_ts.to_rfc3339_opts(SecondsFormat::Secs, true)],
         card_history,
     );
     assert_eq!(collection_history.size(), 5);

--- a/mtgoparser/tests/mtgoparser_history.rs
+++ b/mtgoparser/tests/mtgoparser_history.rs
@@ -1,0 +1,71 @@
+mod util;
+
+use chrono::NaiveDateTime;
+use mtgoparser::mtgo_card::{
+    card_history::CardHistory, collection_history::CollectionHistory, MtgoCard,
+};
+use util::*;
+
+// Utility for the tests to start of with a vector of `MtgoCard`
+fn get_3000_mtgo_card_vector() -> Vec<MtgoCard> {
+    match mtgoparser::parse_full(
+        FULL_TRADELIST_MEDIUM_FULL_PATH.as_path(),
+        SCRYFALL_FULL_PATH.as_path(),
+        CARD_DEFINITIONS_FULL_PATH.as_path(),
+        PRICE_HISTORY_FULL_PATH.as_path(),
+        None,
+    ) {
+        Ok(cards) => {
+            assert_eq!(3000, cards.len());
+            cards
+        }
+        Err(e) => {
+            panic!("MTGO Parser error: {e}")
+        }
+    }
+}
+
+#[test]
+pub fn test_parse_to_history() -> TestResult {
+    let card_histories: Vec<CardHistory> = get_3000_mtgo_card_vector()
+        .into_iter()
+        .map(|c| CardHistory::from_mtgo_card(c))
+        .collect();
+    assert_eq!(card_histories.len(), 3000);
+
+    let timestamp =
+        NaiveDateTime::parse_from_str("2023-11-06T083944Z", "%Y-%m-%dT%H%M%SZ").unwrap();
+    let timestamp_str = timestamp.format("%Y-%m-%dT%H%M%SZ");
+    eprintln!("Timestamp: {timestamp_str}");
+    for c in card_histories.iter() {
+        eprintln!("{}", c.to_csv_row());
+    }
+
+    let mut collection_history = CollectionHistory::from_card_history(
+        vec![timestamp_str.to_string()],
+        card_histories.clone(),
+    );
+
+    let timestamp2 = timestamp.checked_add_days(chrono::Days::new(1)).unwrap();
+    let timestamp2_str = timestamp.format("%Y-%m-%dT%H%M%SZ");
+    let collection_history2 =
+        CollectionHistory::from_card_history(vec![timestamp2_str.to_string()], card_histories);
+
+    let mut new_different_cards = get_3000_mtgo_card_vector();
+    new_different_cards.get_mut(3).unwrap().id = 7;
+
+    new_different_cards.get_mut(2).unwrap().goatbots_price = 1234.5;
+
+    new_different_cards.get_mut(2).unwrap().goatbots_price = 1234.5;
+    new_different_cards.get_mut(2).unwrap().scryfall_price = None;
+
+    collection_history.add_new_card_data(timestamp2_str.to_string(), new_different_cards);
+
+    let csv = collection_history.to_csv_string();
+    eprintln!("{csv}");
+
+    for (i, l) in csv.lines().enumerate() {
+        eprintln!("{i}: {l}");
+    }
+    Ok(())
+}

--- a/mtgoparser/tests/util/mod.rs
+++ b/mtgoparser/tests/util/mod.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code)]
+/// Common imports/use for tests
+use once_cell::sync::Lazy;
+
+#[allow(unused_imports)]
+pub use {
+    std::{
+        fs,
+        path::{Path, PathBuf},
+    },
+    testresult::TestResult,
+};
+
+#[allow(unused_imports)]
+use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
+
+pub static SCRYFALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgogetter-out/scryfall-20231002-full.json"));
+pub static SCRYFALL_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/scryfall/default-cards-small-5cards.json"));
+pub static CARD_DEFINITIONS_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json"));
+pub static CARD_DEFINITIONS_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-defs-small-5cards.json"));
+pub static PRICE_HISTORY_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json"));
+pub static PRICE_HISTORY_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-hist-small-5cards.json"));
+pub static FULL_TRADELIST_MEDIUM_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek"));
+pub static FULL_TRADELIST_SMALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from(r"../test/test-data/mtgo/Full Trade List-small-5cards.dek"));

--- a/mtgoupdater/Cargo.toml
+++ b/mtgoupdater/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 chrono.workspace = true
 serde.workspace = true
 zip.workspace = true
+once_cell.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/mtgoupdater/src/lib.rs
+++ b/mtgoupdater/src/lib.rs
@@ -1,11 +1,8 @@
 #![allow(dead_code)]
 
 use std::error;
-use std::ffi::OsStr;
-use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
-use std::sync::OnceLock;
 
 pub mod date;
 pub mod new_update_all;
@@ -16,9 +13,6 @@ use zip_util::Archive;
 use zip_util::Archived;
 use zip_util::UnArchived;
 
-static MTGOGETTER_BIN: OnceLock<OsString> = OnceLock::new();
-static MTGOPARSER_BIN: OnceLock<OsString> = OnceLock::new();
-
 pub use mtgoparser::mtgo_card::MtgoCard;
 pub use mtgoparser::mtgo_card::Rarity;
 pub use mtgoparser::parse_full;
@@ -26,39 +20,6 @@ pub use mtgoparser::parse_full;
 /// Returns the version of `MTGO Updater`
 pub fn mtgo_updater_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
-}
-
-/// Sets the path to the `MTGO Getter` binary
-///
-/// # Arguments
-///
-/// * `bin_path` - Path to the `MTGO Getter` binary
-///
-/// # Errors
-///
-/// Returns an error if path has already been set.
-pub fn set_mtgogetter_bin(bin_path: OsString) -> Result<(), OsString> {
-    MTGOGETTER_BIN.set(bin_path)
-}
-
-/// Gets the path to the `MTGO Getter` binary
-///
-/// If the path has not been set, it will be set to the default path relative to the current executable
-///
-/// # Panics
-///
-/// Panics if the current executable path cannot be determined
-pub(crate) fn mtgogetter_bin() -> &'static OsStr {
-    MTGOGETTER_BIN.get_or_init(|| {
-        let mut path = std::env::current_exe().expect("Failed to get current executable path");
-        path.pop();
-        path.push("bin");
-        path.push("mtgogetter");
-        if cfg!(windows) {
-            path.set_extension(std::env::consts::EXE_EXTENSION);
-        }
-        path.into_os_string()
-    })
 }
 
 /// Finds all price history JSON-files (pattern `mtgo-cards_YYYY-MM-DDTHHMMSSZ`) in

--- a/mtgoupdater/tests/mtgoupdater_mtgoparser.rs
+++ b/mtgoupdater/tests/mtgoupdater_mtgoparser.rs
@@ -1,25 +1,27 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
+
+static STATE_LOG_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgogetter-out/fetch_log.toml"));
+static SCRYFALL_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgogetter-out/scryfall-20231002-full.json"));
+static CARD_DEFINITIONS_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json"));
+static PRICE_HISTORY_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json"));
+static FULL_TRADELIST_MEDIUM_FULL_PATH: Lazy<PathBuf> =
+    Lazy::new(|| PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek"));
 
 #[test]
 fn test_full_parse_3000cards_from_pathbuf() {
-    let scryfall_path =
-        PathBuf::from("../test/test-data/mtgogetter-out/scryfall-20231002-full.json");
-    let card_definitions_path =
-        PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json");
-    let price_history_path =
-        PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json");
-
-    let full_trade_list_path =
-        PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek");
-
     match mtgoupdater::parse_full(
-        full_trade_list_path.as_path(),
-        scryfall_path.as_path(),
-        card_definitions_path.as_path(),
-        price_history_path.as_path(),
+        FULL_TRADELIST_MEDIUM_FULL_PATH.as_path(),
+        SCRYFALL_FULL_PATH.as_path(),
+        CARD_DEFINITIONS_FULL_PATH.as_path(),
+        PRICE_HISTORY_FULL_PATH.as_path(),
         None,
     ) {
         Ok(cards) => {
@@ -37,21 +39,15 @@ fn test_full_parse_3000cards_from_pathbuf() {
 
 #[test]
 fn test_full_parse_3000cards_bad_path() {
-    let scryfall_path = Path::new("../test/test-data/mtgogetter-out/scryfall-20231002-full.json");
-    let card_definitions_path =
-        Path::new("../test/test-data/goatbots/card-definitions-2023-10-02-full.json");
-    let price_history_path =
-        Path::new("../test/test-data/goatbots/price-history-2023-10-02-full.json");
-
     let full_trade_list_path_bad =
         Path::new("../test/test-data/mtgo/Full Trade List-medium-3000cards.dekx"); // extra x in the end
 
     // Invoke MTGO parser-rs
     match mtgoupdater::parse_full(
         full_trade_list_path_bad,
-        scryfall_path,
-        card_definitions_path,
-        price_history_path,
+        SCRYFALL_FULL_PATH.as_path(),
+        CARD_DEFINITIONS_FULL_PATH.as_path(),
+        PRICE_HISTORY_FULL_PATH.as_path(),
         None,
     ) {
         Ok(cards) => {
@@ -72,17 +68,9 @@ fn test_full_parse_3000cards_from_path_with_save_to_dir() {
     let local_test_dir = "target/test_full_parse_3000cards_from_path_with_save_to_dir/";
     fs::create_dir_all(local_test_dir).unwrap();
 
-    let card_definitions_path =
-        PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json");
-    let price_history_path =
-        PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json");
-
-    let full_trade_list_path =
-        PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek");
-
     let save_to_dir = Path::new(local_test_dir);
 
-    let state_log_path = PathBuf::from("../test/test-data/mtgogetter-out/fetch_log.toml");
+    let state_log_path = STATE_LOG_PATH.clone();
     assert!(state_log_path.exists());
     let mut save_to_dir_state_log = save_to_dir.to_path_buf();
     save_to_dir_state_log.push("fetch_log.toml");
@@ -92,12 +80,12 @@ fn test_full_parse_3000cards_from_path_with_save_to_dir() {
     )
     .unwrap();
 
-    // Invoke MTGO parser-rs
+    // Invoke MTGO parser
     match mtgoupdater::parse_full(
-        full_trade_list_path.as_path(),
-        Path::new("../test/test-data/mtgogetter-out/scryfall-20231002-full.json"),
-        card_definitions_path.as_path(),
-        price_history_path.as_path(),
+        FULL_TRADELIST_MEDIUM_FULL_PATH.as_path(),
+        SCRYFALL_FULL_PATH.as_path(),
+        CARD_DEFINITIONS_FULL_PATH.as_path(),
+        PRICE_HISTORY_FULL_PATH.as_path(),
         Some(save_to_dir),
     ) {
         Ok(cards) => {
@@ -124,16 +112,9 @@ fn test_full_parse_3000cards_from_path_with_save_to_dir_state_log() {
     let local_test_dir = "target/test_full_parse_3000cards_from_path_with_save_to_dir_state_log/";
     fs::create_dir_all(local_test_dir).unwrap();
 
-    let card_definitions_path =
-        PathBuf::from("../test/test-data/goatbots/card-definitions-2023-10-02-full.json");
-    let price_history_path =
-        PathBuf::from("../test/test-data/goatbots/price-history-2023-10-02-full.json");
-
-    let full_trade_list_path =
-        PathBuf::from("../test/test-data/mtgo/Full Trade List-medium-3000cards.dek");
     let save_to_dir = Path::new("target/");
 
-    let state_log_path = PathBuf::from("../test/test-data/mtgogetter-out/fetch_log.toml");
+    let state_log_path = STATE_LOG_PATH.clone();
     assert!(state_log_path.exists());
     let mut save_to_dir_state_log = save_to_dir.to_path_buf();
     save_to_dir_state_log.push("fetch_log.toml");
@@ -144,10 +125,10 @@ fn test_full_parse_3000cards_from_path_with_save_to_dir_state_log() {
     .unwrap();
 
     match mtgoupdater::parse_full(
-        full_trade_list_path.as_path(),
-        Path::new("../test/test-data/mtgogetter-out/scryfall-20231002-full.json"),
-        card_definitions_path.as_path(),
-        price_history_path.as_path(),
+        FULL_TRADELIST_MEDIUM_FULL_PATH.as_path(),
+        SCRYFALL_FULL_PATH.as_path(),
+        CARD_DEFINITIONS_FULL_PATH.as_path(),
+        PRICE_HISTORY_FULL_PATH.as_path(),
         Some(save_to_dir),
     ) {
         Ok(cards) => {


### PR DESCRIPTION
Still needs work.

- [ ] `add_new_card_data` needs a massive refactor to improve readability and reduce duplication
- [ ] CSV serializing/deserializing needs to account for a reload of the full trade list and subsequent updating of all price data
